### PR TITLE
Fix CORS for custom domains and auth gate bypass on connection failure

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -42,9 +42,10 @@ app = FastAPI(
 
 # CORS
 frontend_url = os.environ.get("FRONTEND_URL", "http://localhost:3000")
+extra_origins = [o.strip() for o in os.environ.get("EXTRA_ORIGINS", "").split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[frontend_url, "http://localhost:3000"],
+    allow_origins=[frontend_url, "http://localhost:3000"] + extra_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -37,8 +37,8 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
         }
       })
       .catch(() => {
-        // If we can't reach the backend, let through and let API calls fail naturally
-        setAuthenticated(true);
+        // Can't reach backend — assume auth is required so we don't bypass it
+        setAuthRequired(true);
       })
       .finally(() => {
         if (!authRequired) setChecking(false);


### PR DESCRIPTION
- Add EXTRA_ORIGINS env var for additional CORS origins (e.g. Cloudflare domain)
- Fix AuthGate: don't bypass auth when backend is unreachable