### PR TITLE
Improved mobile layout, fixes for starting positions and interval timing

### DIFF
--- a/backend/services/f1_data.py
+++ b/backend/services/f1_data.py
@@ -507,7 +507,24 @@ def _get_driver_positions_by_time_sync(
         grid = row.get("GridPosition")
         if pd.notna(grid):
             grid_val = int(grid)
-            grid_positions[abbr] = grid_val
+            if grid_val > 0:
+                grid_positions[abbr] = grid_val
+
+    # If grid positions are missing (e.g. F1 API returns -1 for all),
+    # fall back to qualifying results position as grid order
+    if is_race and not grid_positions:
+        quali_type = "SQ" if session_type == "S" else "Q"
+        try:
+            quali_session = _load_session(year, round_num, quali_type)
+            for _, row in quali_session.results.iterrows():
+                q_abbr = str(row.get("Abbreviation", ""))
+                q_pos = row.get("Position")
+                if q_abbr and pd.notna(q_pos) and int(q_pos) > 0:
+                    grid_positions[q_abbr] = int(q_pos)
+            if grid_positions:
+                logger.info(f"Grid positions unavailable, using {quali_type} results as fallback ({len(grid_positions)} drivers)")
+        except Exception as e:
+            logger.warning(f"Could not load {quali_type} session for grid fallback: {e}")
 
     # Pre-compute fastest lap holder by lap number
     fastest_by_lap = {}
@@ -848,9 +865,12 @@ def _get_driver_positions_by_time_sync(
     # Load real-time gap-to-leader data from F1 timing feed
     # abbr -> (times_array, gap_strings_array)
     timing_lookup: dict[str, tuple] = {}
+    # abbr -> (times_array, interval_strings_array)
+    interval_lookup: dict[str, tuple] = {}
     try:
         _, timing_df = f1api.timing_data(session.api_path)
         if timing_df is not None and "GapToLeader" in timing_df.columns:
+            has_interval = "IntervalToPositionAhead" in timing_df.columns
             num_to_abbr = {}
             for _, row in session.results.iterrows():
                 num_to_abbr[str(row.get("DriverNumber", ""))] = str(row.get("Abbreviation", ""))
@@ -863,7 +883,10 @@ def _get_driver_positions_by_time_sync(
                 times = drv_data["Time"].dt.total_seconds().values.astype(np.float64)
                 gap_strs = drv_data["GapToLeader"].values
                 timing_lookup[abbr] = (times, gap_strs)
-            logger.info(f"Loaded F1 timing data for {len(timing_lookup)} drivers ({len(timing_df)} entries)")
+                if has_interval:
+                    interval_vals = drv_data["IntervalToPositionAhead"].values
+                    interval_lookup[abbr] = (times, interval_vals)
+            logger.info(f"Loaded F1 timing data for {len(timing_lookup)} drivers ({len(timing_df)} entries), intervals={'yes' if has_interval else 'no'}")
     except Exception as e:
         logger.error(f"Failed to load timing data: {e}")
 
@@ -878,6 +901,21 @@ def _get_driver_positions_by_time_sync(
         if idx < 0:
             return None
         val = gap_strs[idx]
+        if pd.isna(val) or val is None:
+            return None
+        return str(val)
+
+    def _get_interval(abbr: str, t_sec: float) -> str | None:
+        """Get the most recent IntervalToPositionAhead for a driver at time t_sec."""
+        entry = interval_lookup.get(abbr)
+        if entry is None:
+            return None
+        times, interval_vals = entry
+        session_t = t_sec + session_time_offset
+        idx = np.searchsorted(times, session_t, side="right") - 1
+        if idx < 0:
+            return None
+        val = interval_vals[idx]
         if pd.isna(val) or val is None:
             return None
         return str(val)
@@ -900,6 +938,8 @@ def _get_driver_positions_by_time_sync(
 
     # Track last known state for each driver (for showing retired drivers)
     last_known: dict[str, dict] = {}
+    # Track drivers that have ever appeared in telemetry
+    ever_seen: set[str] = set()
 
     for i in range(min(num_samples, 50000)):  # cap to prevent excessive data
         t_sec = i * sample_interval
@@ -921,6 +961,7 @@ def _get_driver_positions_by_time_sync(
                 continue
 
             seen_drivers.add(drv)
+            ever_seen.add(drv)
             def _safe_float(v) -> float:
                 f = float(v)
                 return 0.0 if np.isnan(f) or np.isinf(f) else f
@@ -935,6 +976,7 @@ def _get_driver_positions_by_time_sync(
             drs_val = int(arrays["drs"][idx]) if not np.isnan(arrays["drs"][idx]) else 0
 
             gap = _get_gap_to_leader(drv, t_sec) if is_race else None
+            interval = _get_interval(drv, t_sec) if is_race else None
             grid_pos = grid_positions.get(drv) if is_race else None
             is_pit_lane_starter = grid_pos == 0 if is_race else False
             show_pit_badge = is_pit_lane_starter and t_sec < 10
@@ -965,6 +1007,7 @@ def _get_driver_positions_by_time_sync(
                 "has_fastest_lap": False,  # set after sorting
                 "flag": _get_driver_flag(drv, t_sec),
                 "gap": gap,
+                "interval": interval,
                 "no_timing": gap is None,
                 "retired": False,
                 "relative_distance": rel_dist,
@@ -978,21 +1021,99 @@ def _get_driver_positions_by_time_sync(
             last_known[drv] = drv_data
             frame_drivers.append(drv_data)
 
-        # Add retired drivers that have dropped out of telemetry
+        # Add drivers that have dropped out of telemetry back to the frame
+        # so they always appear on the leaderboard
         for drv in driver_arrays:
-            if drv not in seen_drivers and drv in last_known and drv in retired_drivers:
-                retired_data = {**last_known[drv], "retired": True, "gap": None, "no_timing": False}
-                frame_drivers.append(retired_data)
+            if drv not in seen_drivers and drv in last_known:
+                is_retired = drv in retired_drivers
+                restored = {**last_known[drv], "gap": None, "interval": None}
+                if is_retired:
+                    restored["retired"] = True
+                    restored["no_timing"] = False
+                else:
+                    # Telemetry gap — grey out but keep on leaderboard
+                    restored["no_timing"] = True
+                frame_drivers.append(restored)
+
+        # Add drivers who have grid positions but never appeared in telemetry
+        # (e.g. DNS — crashed before formation lap). Show as "Out" after 10s.
+        if is_race and t_sec >= 10:
+            for drv, gp in grid_positions.items():
+                if drv not in seen_drivers and drv not in ever_seen:
+                    frame_drivers.append({
+                        "abbr": drv,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "color": colors.get(drv, "#FFFFFF"),
+                        "team": teams.get(drv, ""),
+                        "position": None,
+                        "grid_position": gp if gp and gp > 0 else None,
+                        "pit_start": False,
+                        "in_pit": False,
+                        "compound": None,
+                        "tyre_life": None,
+                        "pit_stops": 0,
+                        "has_fastest_lap": False,
+                        "flag": None,
+                        "gap": None,
+                        "interval": None,
+                        "no_timing": False,
+                        "retired": True,
+                        "relative_distance": 0.0,
+                        "speed": 0.0,
+                        "throttle": 0.0,
+                        "brake": False,
+                        "gear": 0,
+                        "rpm": 0.0,
+                        "drs": 0,
+                        "tyre_history": [],
+                    })
 
         if is_race:
-            # First 10 seconds: use grid positions, no gap display, no greying
+            # First 10 seconds: use telemetry for track map x/y,
+            # but lock leaderboard positions to grid order
             if t_sec < 10:
+                # Add drivers missing from telemetry so they appear on leaderboard
+                for drv, gp in grid_positions.items():
+                    if gp is None or drv in seen_drivers:
+                        continue
+                    is_pit_lane = gp == 0
+                    frame_drivers.append({
+                        "abbr": drv,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "color": colors.get(drv, "#FFFFFF"),
+                        "team": teams.get(drv, ""),
+                        "position": None,
+                        "grid_position": gp if not is_pit_lane else None,
+                        "pit_start": is_pit_lane,
+                        "in_pit": False,
+                        "compound": None,
+                        "tyre_life": None,
+                        "pit_stops": 0,
+                        "has_fastest_lap": False,
+                        "flag": None,
+                        "gap": None,
+                        "interval": None,
+                        "no_timing": True,
+                        "retired": False,
+                        "relative_distance": 0.0,
+                        "speed": 0.0,
+                        "throttle": 0.0,
+                        "brake": False,
+                        "gear": 0,
+                        "rpm": 0.0,
+                        "drs": 0,
+                        "tyre_history": [],
+                    })
+                # Override positions with grid order for all drivers
+                # All drivers appear normal on leaderboard during first 10 seconds
                 for d in frame_drivers:
                     gp = grid_positions.get(d["abbr"])
-                    d["position"] = gp if gp and gp > 0 else len(frame_drivers)
+                    d["position"] = gp if gp and gp > 0 else None
                     d["gap"] = None
                     d["no_timing"] = False
-                frame_drivers.sort(key=lambda d: d["position"])
+                frame_drivers.sort(key=lambda d: (d["position"] is None, d["position"] or 0))
             else:
                 # Derive positions by sorting on gap-to-leader
                 # Drivers with gap data are ranked by gap value; drivers without go to the bottom

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   icons: {
     icon: "/favicon.png",
   },
+  viewport: "width=device-width, initial-scale=1, viewport-fit=cover",
 };
 
 export default function RootLayout({

--- a/frontend/src/app/replay/[year]/[round]/page.tsx
+++ b/frontend/src/app/replay/[year]/[round]/page.tsx
@@ -156,7 +156,7 @@ export default function ReplayPage() {
       )}
 
       {/* Main content */}
-      <div className="flex-1 flex flex-col sm:flex-row min-h-0 overflow-y-auto sm:overflow-hidden">
+      <div className="flex-1 flex flex-col sm:flex-row min-h-0 overflow-y-auto sm:overflow-hidden pb-20 sm:pb-0">
         {/* Track section */}
         <div className="sm:flex-1 relative">
           {/* Mobile section header */}
@@ -173,7 +173,7 @@ export default function ReplayPage() {
           )}
 
           {(!isMobile || mobileTrackOpen) && (
-            <div className="h-[35vh] sm:h-full relative">
+            <div className="h-[42vh] sm:h-full relative">
               {/* Flag badge */}
               {trackStatus !== "green" && (
                 <div className="absolute top-3 left-1/2 -translate-x-1/2 z-10">
@@ -203,7 +203,7 @@ export default function ReplayPage() {
                 trackPoints={trackPoints}
                 rotation={rotation}
                 trackStatus={trackStatus}
-                drivers={drivers.filter((d) => !d.retired).map((d) => ({
+                drivers={drivers.filter((d) => !d.retired && !d.no_timing && (d.x !== 0 || d.y !== 0)).map((d) => ({
                   abbr: d.abbr,
                   x: d.x,
                   y: d.y,

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -16,9 +16,17 @@ interface Props {
 
 function formatGap(gap: string | null): string {
   if (!gap) return "";
-  const match = gap.match(/^(\d+)\s*L$/);
-  if (match) {
-    const n = parseInt(match[1]);
+  // Handle "1L", "2L" format (gap to leader)
+  const lapped = gap.match(/^(\d+)\s*L$/);
+  if (lapped) {
+    const n = parseInt(lapped[1]);
+    return `+${n} Lap${n > 1 ? "s" : ""}`;
+  }
+  // Handle "LAP 1", "LAP 0" format (interval data)
+  const lapFormat = gap.match(/^LAP\s+(\d+)$/i);
+  if (lapFormat) {
+    const n = parseInt(lapFormat[1]);
+    if (n === 0) return "Interval";
     return `+${n} Lap${n > 1 ? "s" : ""}`;
   }
   return gap;
@@ -44,24 +52,14 @@ function computeIntervals(sorted: ReplayDriver[]): Map<string, string> {
       intervals.set(drv.abbr, "Leader");
       continue;
     }
-    const currGap = parseGapSeconds(drv.gap);
-    const prevGap = parseGapSeconds(sorted[i - 1].gap);
-    // Lapped cars: show laps behind
-    const lapped = drv.gap?.match(/^(\d+)\s*L$/);
-    if (lapped) {
-      const prevLapped = sorted[i - 1].gap?.match(/^(\d+)\s*L$/);
-      if (prevLapped) {
-        const diff = parseInt(lapped[1]) - parseInt(prevLapped[1]);
-        if (diff > 0) {
-          intervals.set(drv.abbr, `+${diff} Lap${diff > 1 ? "s" : ""}`);
-        } else {
-          intervals.set(drv.abbr, "+0.000");
-        }
-      } else {
-        intervals.set(drv.abbr, `+${lapped[1]} Lap${parseInt(lapped[1]) > 1 ? "s" : ""}`);
-      }
+    // Use real interval data from F1 timing feed if available
+    if (drv.interval) {
+      intervals.set(drv.abbr, formatGap(drv.interval));
       continue;
     }
+    // Fallback: compute from gap-to-leader differences
+    const currGap = parseGapSeconds(drv.gap);
+    const prevGap = parseGapSeconds(sorted[i - 1].gap);
     if (currGap !== null && prevGap !== null) {
       const diff = currGap - prevGap;
       intervals.set(drv.abbr, `+${diff.toFixed(3)}`);
@@ -240,7 +238,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Gap / best time - 56px */}
               {settings.showGapToLeader && (
-                <span className={`w-14 flex-shrink-0 text-xs font-bold text-right ${drv.in_pit && isRace ? "text-yellow-400" : isRace ? "text-f1-muted" : drv.position === 1 ? "text-purple-400" : "text-f1-muted"}`}>
+                <span className={`w-14 flex-shrink-0 text-xs font-bold text-right ${drv.in_pit && isRace && !drv.retired ? "text-yellow-400" : isRace ? "text-f1-muted" : drv.position === 1 ? "text-purple-400" : "text-f1-muted"}`}>
                   {displayGap}
                 </span>
               )}

--- a/frontend/src/components/PlaybackControls.tsx
+++ b/frontend/src/components/PlaybackControls.tsx
@@ -110,9 +110,9 @@ export default function PlaybackControls({
 
   // Mobile compact layout
   return (
-    <div className="bg-f1-card border-t border-f1-border">
+    <div className="bg-f1-card border-t border-f1-border fixed bottom-0 left-0 right-0 z-40 sm:relative sm:z-auto">
       {/* Mobile: compact bar always visible */}
-      <div className="sm:hidden px-3 pt-2 pb-1">
+      <div className="sm:hidden px-3 pt-2 pb-4" style={{ paddingBottom: "max(1rem, env(safe-area-inset-bottom, 1rem))" }}>
         <div className="mb-2">{progressBar}</div>
         <div className="flex items-center gap-2">
           {playPauseBtn}
@@ -135,7 +135,7 @@ export default function PlaybackControls({
 
       {/* Mobile: expanded controls */}
       {expanded && (
-        <div className="sm:hidden px-3 pb-2 space-y-2 border-t border-f1-border/50 pt-2">
+        <div className="sm:hidden px-3 space-y-2 border-t border-f1-border/50 pt-2 pb-4" style={{ paddingBottom: "max(1rem, env(safe-area-inset-bottom, 1rem))" }}>
           {/* Skip buttons */}
           <div className="flex items-center justify-center gap-1">
             {[...SKIP_OPTIONS].reverse().map(({ label, seconds }) => (

--- a/frontend/src/components/SessionBanner.tsx
+++ b/frontend/src/components/SessionBanner.tsx
@@ -360,14 +360,25 @@ export default function SessionBanner({
                 </h3>
                 <p className="text-sm text-f1-muted leading-relaxed">
                   Driver positions and gap times are sourced directly from the official
-                  F1 live timing feed  - the same data used by the broadcast. Positions
+                  F1 live timing feed — the same data used by the broadcast. Positions
                   are determined by sorting drivers on their gap to the leader, which
                   updates multiple times per lap at sector and mini-sector boundaries.
                 </p>
+              </div>
+
+              {/* Starting Grid */}
+              <div>
+                <h3 className="text-sm font-bold text-f1-red uppercase tracking-wider mb-2">
+                  Starting grid
+                </h3>
+                <p className="text-sm text-f1-muted leading-relaxed">
+                  For the first 10 seconds of the race, the leaderboard displays the
+                  starting grid order before live timing data takes over.
+                </p>
                 <p className="text-sm text-f1-muted leading-relaxed mt-2">
-                  For the first few seconds of the race, the starting grid order is
-                  shown before timing data becomes available. Grid position changes
-                  are only displayed after 10 seconds to ensure accuracy.
+                  Where official starting grid data is unavailable, qualifying
+                  positions are used as a fallback. This may not reflect grid
+                  penalties or other post-qualifying changes to the starting order.
                 </p>
               </div>
 

--- a/frontend/src/hooks/useReplaySocket.ts
+++ b/frontend/src/hooks/useReplaySocket.ts
@@ -17,6 +17,7 @@ export interface ReplayDriver {
   in_pit: boolean;
   tyre_history: string[];
   gap: string | null;
+  interval: string | null;
   has_fastest_lap: boolean;
   flag: "investigation" | "penalty" | null;
   retired: boolean;


### PR DESCRIPTION
Improved mobile layout, including track map rendering and playback controls
Drivers with unavailable position data are now temporarily hidden from the track map and restored automatically when data resumes
Starting grid positions now fall back to qualifying result data when grid position data is unavailable
Retired drivers now remain on the leaderboard in their final position, marked as "Out"
Overall improvements to interval timing, including handling of lapped drivers
Minor UI consistency fixes