### PR TITLE
Feat: add clipboard paste support for leaderboard sync by Clav3rbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <h1><img src="https://github.com/user-attachments/assets/158de3d0-8bd5-41a5-a34d-a3a92471cf96" width="50" align="absmiddle" /> F1 Replay Timing</h1>
 
+
+https://github.com/user-attachments/assets/618597ae-d6e6-4793-bc4d-3f72dd410973
+
+
 > **Disclaimer:** This project is intended for **personal, non-commercial use only**. This website is unofficial and is not associated in any way with the Formula 1 companies. F1, FORMULA ONE, FORMULA 1, FIA FORMULA ONE WORLD CHAMPIONSHIP, GRAND PRIX and related marks are trade marks of Formula One Licensing B.V.
 
 A web app that lets you replay past Formula 1 sessions with real timing data, car positions on track, driver telemetry, and more. Built with Next.js and FastAPI.

--- a/frontend/src/components/SyncPhoto.tsx
+++ b/frontend/src/components/SyncPhoto.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { getToken } from "@/lib/auth";
 
 interface Props {
@@ -49,6 +49,26 @@ export default function SyncPhoto({
   const [manualProcessing, setManualProcessing] = useState(false);
 
   const MAX_UPLOAD_BYTES = 20 * 1024 * 1024; // 20MB backend limit
+
+  const handlePaste = useCallback((e: ClipboardEvent) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].type.startsWith("image/")) {
+        e.preventDefault();
+        const file = items[i].getAsFile();
+        if (file) handleFile(file);
+        return;
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (step === "processing" || step === "result") return;
+    document.addEventListener("paste", handlePaste);
+    return () => document.removeEventListener("paste", handlePaste);
+  }, [step, handlePaste]);
 
   async function handleFile(file: File) {
     setStep("processing");
@@ -315,6 +335,19 @@ export default function SyncPhoto({
                     </svg>
                     Upload Image
                   </button>
+
+                  <div className="flex items-center gap-2 justify-center">
+                    <div className="h-px flex-1 bg-f1-border" />
+                    <span className="text-xs text-f1-muted">or</span>
+                    <div className="h-px flex-1 bg-f1-border" />
+                  </div>
+
+                  <p className="text-center text-sm text-f1-muted">
+                    <kbd className="px-1.5 py-0.5 bg-f1-border rounded text-xs font-mono text-white">Ctrl</kbd>{" "}
+                    +{" "}
+                    <kbd className="px-1.5 py-0.5 bg-f1-border rounded text-xs font-mono text-white">V</kbd>{" "}
+                    to paste from clipboard
+                  </p>
 
                   <input
                     ref={cameraInputRef}


### PR DESCRIPTION
Add Ctrl+V clipboard paste support to the SyncPhoto component, allowing users to paste a screenshot of the F1 TV broadcast leaderboard directly from their clipboard instead of having to upload a file.