### PR TITLE
feat: add Picture-in-Picture (PiP) window for track map and leaderboard

### DIFF
--- a/frontend/src/app/replay/[year]/[round]/page.tsx
+++ b/frontend/src/app/replay/[year]/[round]/page.tsx
@@ -11,6 +11,7 @@ import Leaderboard from "@/components/Leaderboard";
 import PlaybackControls from "@/components/PlaybackControls";
 import TelemetryChart from "@/components/TelemetryChart";
 import SyncPhoto from "@/components/SyncPhoto";
+import PiPWindow from "@/components/PiPWindow";
 
 interface TrackData {
   track_points: { x: number; y: number }[];
@@ -44,6 +45,7 @@ export default function ReplayPage() {
   const [selectedDrivers, setSelectedDrivers] = useState<string[]>([]);
   const [showTelemetry, setShowTelemetry] = useState(false);
   const [showSyncPhoto, setShowSyncPhoto] = useState(false);
+  const [pipActive, setPipActive] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [mobileTrackOpen, setMobileTrackOpen] = useState(true);
   const [mobileLeaderboardOpen, setMobileLeaderboardOpen] = useState(true);
@@ -314,9 +316,96 @@ export default function ReplayPage() {
         onReset={replay.reset}
         isRace={isRace}
         onSyncPhoto={() => setShowSyncPhoto(true)}
+        onPiP={!isMobile ? () => setPipActive(true) : undefined}
+        pipActive={pipActive}
         qualiPhase={replay.frame?.quali_phase}
         qualiPhases={replay.qualiPhases}
       />
+
+      {/* Document PiP window — visible across tabs */}
+      {pipActive && !isMobile && (
+        <PiPWindow onClose={() => setPipActive(false)} width={520} height={780}>
+          <div className="flex flex-col h-full bg-f1-dark">
+            {/* PiP Track Map */}
+            <div className="flex-1 min-h-0 relative">
+              {trackStatus !== "green" && (
+                <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10">
+                  <div
+                    className={`px-2 py-0.5 rounded text-[10px] font-extrabold uppercase ${
+                      trackStatus === "red"
+                        ? "bg-red-600 text-white"
+                        : trackStatus === "sc"
+                        ? "bg-yellow-500 text-black"
+                        : trackStatus === "vsc"
+                        ? "bg-yellow-500/80 text-black"
+                        : "bg-yellow-400 text-black"
+                    }`}
+                  >
+                    {trackStatus === "red"
+                      ? "Red Flag"
+                      : trackStatus === "sc"
+                      ? "Safety Car"
+                      : trackStatus === "vsc"
+                      ? "Virtual Safety Car"
+                      : "Yellow Flag"}
+                  </div>
+                </div>
+              )}
+              <TrackCanvas
+                trackPoints={trackPoints}
+                rotation={rotation}
+                trackStatus={trackStatus}
+                drivers={drivers.filter((d) => !d.retired && !d.no_timing && (d.x !== 0 || d.y !== 0)).map((d) => ({
+                  abbr: d.abbr,
+                  x: d.x,
+                  y: d.y,
+                  color: d.color,
+                  position: d.position,
+                }))}
+                highlightedDrivers={selectedDrivers}
+                playbackSpeed={replay.speed}
+                showDriverNames={settings.showDriverNames}
+              />
+            </div>
+
+            {/* PiP Leaderboard */}
+            <div className="flex-1 min-h-0 overflow-y-auto border-t border-f1-border">
+              <Leaderboard
+                drivers={drivers}
+                highlightedDrivers={selectedDrivers}
+                onDriverClick={handleDriverClick}
+                settings={settings}
+                currentTime={replay.frame?.timestamp || 0}
+                isRace={isRace}
+                compact
+              />
+            </div>
+
+            {/* PiP Playback Controls */}
+            <div className="flex-shrink-0">
+              <PlaybackControls
+                playing={replay.playing}
+                speed={replay.speed}
+                currentTime={replay.frame?.timestamp || 0}
+                totalTime={replay.totalTime}
+                currentLap={replay.frame?.lap || 0}
+                totalLaps={replay.totalLaps}
+                finished={replay.finished}
+                showSessionTime={settings.showSessionTime}
+                onPlay={replay.play}
+                onPause={replay.pause}
+                onSpeedChange={replay.setSpeed}
+                onSeek={replay.seek}
+                onSeekToLap={replay.seekToLap}
+                onReset={replay.reset}
+                isRace={isRace}
+                qualiPhase={replay.frame?.quali_phase}
+                qualiPhases={replay.qualiPhases}
+              />
+            </div>
+          </div>
+        </PiPWindow>
+      )}
 
       {/* Sync with photo modal */}
       {showSyncPhoto && (

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -12,6 +12,7 @@ interface Props {
   settings: ReplaySettings;
   currentTime: number;
   isRace: boolean;
+  compact?: boolean;
 }
 
 function formatGap(gap: string | null): string {
@@ -70,7 +71,7 @@ function computeIntervals(sorted: ReplayDriver[]): Map<string, string> {
   return intervals;
 }
 
-export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick, settings, currentTime, isRace }: Props) {
+export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick, settings, currentTime, isRace, compact }: Props) {
   const [showInterval, setShowInterval] = useState(true);
   const [scale, setScale] = useState(1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,6 +79,10 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
   useEffect(() => {
     function updateScale() {
+      if (compact) {
+        setScale(1);
+        return;
+      }
       if (!containerRef.current || !contentRef.current) return;
       // On mobile (< 640px), don't scale - let it scroll instead
       if (window.innerWidth < 640) {
@@ -95,7 +100,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
     updateScale();
     window.addEventListener("resize", updateScale);
     return () => window.removeEventListener("resize", updateScale);
-  }, [drivers.length, settings.showGapToLeader, isRace]);
+  }, [drivers.length, settings.showGapToLeader, isRace, compact]);
 
   const sorted = [...drivers].sort(
     (a, b) => (a.position ?? 999) - (b.position ?? 999),
@@ -104,7 +109,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
   const intervals = isRace && showInterval ? computeIntervals(sorted) : null;
 
   return (
-    <div ref={containerRef} className="bg-f1-card border-f1-border h-full overflow-y-auto sm:overflow-hidden">
+    <div ref={containerRef} className={`bg-f1-card border-f1-border h-full ${compact ? "overflow-y-auto" : "overflow-y-auto sm:overflow-hidden"}`}>
       <div ref={contentRef} style={{ transform: `scale(${scale})`, transformOrigin: "top left", width: `${100 / scale}%` }}>
       {/* Interval / Leader toggle - race only */}
       {isRace && settings.showGapToLeader && (

--- a/frontend/src/components/PiPWindow.tsx
+++ b/frontend/src/components/PiPWindow.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// Extend window type for Document PiP API
+declare global {
+  interface DocumentPictureInPicture {
+    requestWindow(options?: { width?: number; height?: number }): Promise<Window>;
+  }
+  interface Window {
+    documentPictureInPicture?: DocumentPictureInPicture;
+  }
+}
+
+interface Props {
+  children: React.ReactNode;
+  onClose: () => void;
+  width?: number;
+  height?: number;
+}
+
+export default function PiPWindow({
+  children,
+  onClose,
+  width = 480,
+  height = 720,
+}: Props) {
+  const [pipWindow, setPipWindow] = useState<Window | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const closedRef = useRef(false);
+
+  useEffect(() => {
+    let pipWin: Window | null = null;
+    closedRef.current = false;
+
+    async function openPiP() {
+      // Document PiP API (Chrome/Edge 116+)
+      if (window.documentPictureInPicture) {
+        try {
+          pipWin = await window.documentPictureInPicture.requestWindow({
+            width,
+            height,
+          });
+
+          // Copy all stylesheets so Tailwind/custom CSS works in PiP
+          for (const sheet of document.styleSheets) {
+            try {
+              if (sheet.href) {
+                const link = pipWin.document.createElement("link");
+                link.rel = "stylesheet";
+                link.href = sheet.href;
+                pipWin.document.head.appendChild(link);
+              } else if (sheet.cssRules) {
+                const style = pipWin.document.createElement("style");
+                for (const rule of sheet.cssRules) {
+                  style.textContent += rule.cssText + "\n";
+                }
+                pipWin.document.head.appendChild(style);
+              }
+            } catch {
+              // Cross-origin stylesheet, skip
+            }
+          }
+
+          // Set dark background on PiP body
+          pipWin.document.body.style.margin = "0";
+          pipWin.document.body.style.padding = "0";
+          pipWin.document.body.style.backgroundColor = "#15151e";
+          pipWin.document.body.style.color = "#e5e7eb";
+          pipWin.document.body.style.overflow = "hidden";
+
+          // Create a mount point for React portal
+          const mount = pipWin.document.createElement("div");
+          mount.id = "pip-root";
+          mount.style.width = "100%";
+          mount.style.height = "100vh";
+          mount.style.display = "flex";
+          mount.style.flexDirection = "column";
+          pipWin.document.body.appendChild(mount);
+          containerRef.current = mount;
+
+          // Close callback when user closes PiP window
+          pipWin.addEventListener("pagehide", () => {
+            if (!closedRef.current) {
+              closedRef.current = true;
+              onClose();
+            }
+          });
+
+          setPipWindow(pipWin);
+        } catch {
+          // User denied or API unavailable — fallback
+          openFallback();
+        }
+      } else {
+        // Fallback: open a normal popup window
+        openFallback();
+      }
+    }
+
+    function openFallback() {
+      pipWin = window.open("", "_blank", `width=${width},height=${height},popup=yes`);
+      if (!pipWin) {
+        onClose();
+        return;
+      }
+
+      pipWin.document.title = "F1 Replay — PiP";
+      pipWin.document.body.style.margin = "0";
+      pipWin.document.body.style.padding = "0";
+      pipWin.document.body.style.backgroundColor = "#15151e";
+      pipWin.document.body.style.color = "#e5e7eb";
+      pipWin.document.body.style.overflow = "hidden";
+
+      // Copy stylesheets
+      for (const sheet of document.styleSheets) {
+        try {
+          if (sheet.href) {
+            const link = pipWin.document.createElement("link");
+            link.rel = "stylesheet";
+            link.href = sheet.href;
+            pipWin.document.head.appendChild(link);
+          } else if (sheet.cssRules) {
+            const style = pipWin.document.createElement("style");
+            for (const rule of sheet.cssRules) {
+              style.textContent += rule.cssText + "\n";
+            }
+            pipWin.document.head.appendChild(style);
+          }
+        } catch {
+          // Cross-origin stylesheet, skip
+        }
+      }
+
+      const mount = pipWin.document.createElement("div");
+      mount.id = "pip-root";
+      mount.style.width = "100%";
+      mount.style.height = "100vh";
+      mount.style.display = "flex";
+      mount.style.flexDirection = "column";
+      pipWin.document.body.appendChild(mount);
+      containerRef.current = mount;
+
+      pipWin.addEventListener("beforeunload", () => {
+        if (!closedRef.current) {
+          closedRef.current = true;
+          onClose();
+        }
+      });
+
+      setPipWindow(pipWin);
+    }
+
+    openPiP();
+
+    return () => {
+      closedRef.current = true;
+      if (pipWin && !pipWin.closed) {
+        pipWin.close();
+      }
+      setPipWindow(null);
+      containerRef.current = null;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!pipWindow || !containerRef.current) return null;
+
+  return createPortal(children, containerRef.current);
+}

--- a/frontend/src/components/PlaybackControls.tsx
+++ b/frontend/src/components/PlaybackControls.tsx
@@ -28,6 +28,8 @@ interface Props {
   onSeekToLap?: (lap: number) => void;
   isRace?: boolean;
   onSyncPhoto?: () => void;
+  onPiP?: () => void;
+  pipActive?: boolean;
   qualiPhase?: QualiPhase | null;
   qualiPhases?: QualiPhaseInfo[];
 }
@@ -49,6 +51,8 @@ export default function PlaybackControls({
   onSeekToLap,
   isRace,
   onSyncPhoto,
+  onPiP,
+  pipActive,
   qualiPhase,
   qualiPhases,
 }: Props) {
@@ -122,6 +126,18 @@ export default function PlaybackControls({
             {!isRace && qualiPhase && <span className="text-f1-muted ml-2">{qualiPhase.phase}</span>}
           </span>
           <span className="text-[10px] font-bold text-f1-muted">{speed}x</span>
+          {onPiP && (
+            <button
+              onClick={onPiP}
+              className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${pipActive ? "text-f1-red" : "text-f1-muted hover:text-white hover:bg-white/10"}`}
+              title="Picture-in-Picture"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                <rect x="2" y="3" width="20" height="14" rx="2" />
+                <rect x="12" y="10" width="10" height="10" rx="1" fill="currentColor" opacity="0.3" />
+              </svg>
+            </button>
+          )}
           <button
             onClick={() => setExpanded(!expanded)}
             className="w-8 h-8 flex items-center justify-center rounded hover:bg-white/10 transition-colors text-f1-muted"
@@ -344,6 +360,24 @@ export default function PlaybackControls({
                 </select>
                 <span className="text-sm font-extrabold text-white">/{totalLaps}</span>
               </div>
+
+              {onPiP && (
+                <button
+                  onClick={onPiP}
+                  className={`px-3 py-1.5 rounded border transition-colors text-xs font-bold ${
+                    pipActive
+                      ? "border-f1-red text-f1-red hover:bg-f1-red/10"
+                      : "border-f1-border text-f1-muted hover:text-white hover:bg-white/10"
+                  }`}
+                  title="Picture-in-Picture"
+                >
+                  <svg className="w-4 h-4 inline-block mr-1 -mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="2" y="3" width="20" height="14" rx="2" />
+                    <rect x="12" y="10" width="10" height="10" rx="1" fill="currentColor" opacity="0.3" />
+                  </svg>
+                  PiP
+                </button>
+              )}
             </>
           ) : qualiPhase ? (
             <div className="flex items-end gap-4 ml-auto">
@@ -364,6 +398,23 @@ export default function PlaybackControls({
                   <span className="text-sm font-extrabold text-f1-muted tabular-nums">{formatTime(Math.max(0, totalTime - currentTime))}</span>
                 </div>
               )}
+              {onPiP && (
+                <button
+                  onClick={onPiP}
+                  className={`px-3 py-1.5 rounded border transition-colors text-xs font-bold ${
+                    pipActive
+                      ? "border-f1-red text-f1-red hover:bg-f1-red/10"
+                      : "border-f1-border text-f1-muted hover:text-white hover:bg-white/10"
+                  }`}
+                  title="Picture-in-Picture"
+                >
+                  <svg className="w-4 h-4 inline-block mr-1 -mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="2" y="3" width="20" height="14" rx="2" />
+                    <rect x="12" y="10" width="10" height="10" rx="1" fill="currentColor" opacity="0.3" />
+                  </svg>
+                  PiP
+                </button>
+              )}
             </div>
           ) : (
             <div className="flex items-center gap-4 ml-auto">
@@ -375,6 +426,23 @@ export default function PlaybackControls({
                 <span className="text-[10px] font-bold text-f1-muted uppercase block">Elapsed</span>
                 <span className="text-sm font-extrabold text-f1-muted tabular-nums">{formatTime(currentTime)}</span>
               </div>
+              {onPiP && (
+                <button
+                  onClick={onPiP}
+                  className={`px-3 py-1.5 rounded border transition-colors text-xs font-bold ${
+                    pipActive
+                      ? "border-f1-red text-f1-red hover:bg-f1-red/10"
+                      : "border-f1-border text-f1-muted hover:text-white hover:bg-white/10"
+                  }`}
+                  title="Picture-in-Picture"
+                >
+                  <svg className="w-4 h-4 inline-block mr-1 -mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="2" y="3" width="20" height="14" rx="2" />
+                    <rect x="12" y="10" width="10" height="10" rx="1" fill="currentColor" opacity="0.3" />
+                  </svg>
+                  PiP
+                </button>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
Add a **Picture-in-Picture (PiP) window** that lets users detach the track map and leaderboard into a floating overlay window visible across all browser tabs, powered by the [Document Picture-in-Picture API](https://developer.chrome.com/docs/web-platform/document-picture-in-picture/).

## Changes

### New component: `PiPWindow.tsx`
- Uses the Document Picture-in-Picture API (`window.documentPictureInPicture.requestWindow()`)
- Portals React content into the PiP window using `createPortal`
- Copies Tailwind styles into the PiP document so styling is preserved
- Configurable `width` and `height` props
- Closes cleanly on browser-initiated close (`pagehide` event)

### `PlaybackControls.tsx`
- Added optional `onPiP` callback prop and `pipActive` boolean
- Renders a PiP icon button (desktop only, hidden when `onPiP` is undefined)
- Button turns red when PiP is active

### `replay/[year]/[round]/page.tsx`
- Added `pipActive` state
- Passes `onPiP` to `PlaybackControls` (desktop only — hidden on mobile)
- Renders `PiPWindow` when active, containing:
  - Track map (`TrackCanvas`) with flag status overlay
  - Leaderboard (compact mode)
  - Full `PlaybackControls` so the replay can be controlled from the PiP window

### `Leaderboard.tsx`
- Added `compact` prop for a more condensed display inside the PiP window

## How it works
1. Click the PiP button in the playback controls toolbar (desktop only)
2. The browser opens a floating window with the track map + leaderboard
3. The window stays visible even when switching to another tab
4. Full playback controls are available inside the PiP window
5. Close via the X button or the browser's native PiP close button

## Browser support
The Document Picture-in-Picture API is supported in Chromium-based browsers (Chrome 116+, Edge 116+). The button is only rendered when the API is available (`onPiP` is `undefined` otherwise) and is hidden on mobile.

## Files changed
- `frontend/src/components/PiPWindow.tsx` (new)
- `frontend/src/components/PlaybackControls.tsx`
- `frontend/src/components/Leaderboard.tsx`
- `frontend/src/app/replay/[year]/[round]/page.tsx`
