### PR TITLE
fix: parse date_utc as UTC in formatLocalTime for correct timezone conversion

### DIFF
--- a/frontend/src/components/SessionPicker.tsx
+++ b/frontend/src/components/SessionPicker.tsx
@@ -85,7 +85,15 @@ const SESSION_LABELS: Record<string, string> = {
 function formatLocalTime(dateUtc: string | null): string | null {
   if (!dateUtc) return null;
   try {
-    const date = new Date(dateUtc);
+    // Ensure the date string is treated as UTC by appending Z if no timezone indicator
+    let utcStr = dateUtc.trim();
+    if (!utcStr.endsWith("Z") && !utcStr.includes("+") && !utcStr.includes("T")) {
+      // Format like "2026-03-15 03:00:00" → "2026-03-15T03:00:00Z"
+      utcStr = utcStr.replace(" ", "T") + "Z";
+    } else if (utcStr.includes("T") && !utcStr.endsWith("Z") && !utcStr.includes("+")) {
+      utcStr += "Z";
+    }
+    const date = new Date(utcStr);
     if (isNaN(date.getTime())) return null;
     return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   } catch {


### PR DESCRIPTION
## What
Fixes `formatLocalTime` in `SessionPicker.tsx` to correctly parse `date_utc` timestamps as UTC before converting to the user's local timezone.

## Why
Session timestamps from the backend arrive as UTC strings (format `YYYY-MM-DD HH:mm:ss`) but were being parsed without explicit UTC designation, causing them to be interpreted as local time. This resulted in incorrect session times displayed to users in non-UTC timezones.

## How
- Appends `Z` suffix to `date_utc` strings before passing to `Date` constructor so the browser correctly interprets them as UTC.
- Local time formatting then correctly converts from UTC to the user's timezone.