### PR TITLE
fix: prevent grid cards from stretching when one is expanded

### DIFF
--- a/frontend/src/components/SessionPicker.tsx
+++ b/frontend/src/components/SessionPicker.tsx
@@ -397,7 +397,7 @@ export default function SessionPicker() {
             <h2 className="text-sm font-bold text-f1-muted uppercase tracking-wider mb-4">
               {year} Season
             </h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 items-start">
               {displayEvents.map((evt) => (
                 <EventCard key={evt.round_number} evt={evt} />
               ))}


### PR DESCRIPTION
## What
Fixes grid card layout in `SessionPicker.tsx` so that expanding one card does not stretch adjacent cards.

## Why
When a session card was expanded (e.g. to show session details), adjacent cards in the same grid row would stretch vertically to match its height, causing an unintended layout shift.

## How
- Changed grid item alignment from `items-stretch` (default) to `items-start` so each card only takes the height it needs.