### PR TITLE
fix: normalize schedule date_utc to ISO 8601 with Z suffix for correct browser timezone conversion

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -57,6 +57,13 @@ def _build_events(year: int) -> dict:
             else:
                 session["available"] = False
 
+        # Normalize date_utc to ISO 8601 with "Z" so the browser
+        # correctly interprets them as UTC and converts to local time
+        for session in evt.get("sessions", []):
+            d = session.get("date_utc")
+            if d and not d.endswith("Z"):
+                session["date_utc"] = d.replace(" ", "T") + "Z"
+
         if has_past_session:
             evt["status"] = "available"
             last_past_idx = i


### PR DESCRIPTION
## Problem

The \date_utc\ values in the static schedule JSON files (e.g. \data/seasons/2026/schedule.json\) use the format \2026-03-15 07:00:00\ without a timezone indicator. When the frontend receives these values, JavaScript's \
ew Date('2026-03-15 07:00:00')\ treats them as **local time** instead of UTC, so users see raw UTC times instead of their local timezone.

## Fix

Normalize \date_utc\ strings in \_build_events()\ before returning the response:
- Replace space separator with \T\ (ISO 8601)
- Append \Z\ suffix to indicate UTC

This ensures the frontend's \FormatLocalTime()\ function correctly interprets dates as UTC and converts them to the user's local timezone via \	oLocaleTimeString()\.

## Example

- **Before:** \2026-03-15 07:00:00\ → browser shows 7:00 AM (wrong, treated as local time)
- **After:** \2026-03-15T07:00:00Z\ → browser shows 8:00 AM CET (correct UTC→local conversion)