### PR TITLE
1.3.0: Lap analysis panel, last lap time column, and mobile improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to F1 Timing Replay will be documented in this file.
 
+## 1.3.0
+
+### New Features
+- **Lap Analysis panel** (Beta) — compare lap times for up to two drivers with a line chart and full lap-by-lap history. Accessible via the Laps button on the track map on desktop, or as a collapsible section on mobile. Race replay only
+- **Last lap time column** — shows each driver's most recently completed lap time on the race leaderboard, toggleable in settings. Race replay only
+- **Leaderboard tooltips** — hover over any column value to see what it is (e.g. "Interval to car ahead", "Tyre age", "Last lap time")
+
+### Improvements
+- **Info button on mobile** — the features/info link is now visible in the mobile header
+- **Features page opens in new tab** — no longer interrupts an active replay session
+
+### Fixes
+- **Mobile qualifying sectors** — sector overlay toggle and driver selection buttons now available on mobile track map, previously desktop-only
+- **Mobile leaderboard spacing** — improved UI layout for mobile Leaderboard
+
+---
+
 ## 1.2.3 — Track detail, telemetry expansion, and race finish improvements
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ A web app for watching Formula 1 sessions with real timing data, car positions o
 ## Features
 
 - **Live timing** (Beta) - connect to live F1 sessions during race weekends with real-time data from the F1 SignalR stream, including a broadcast delay slider and automatic detection of post-session replays
-- **Track map** with real-time car positions from GPS telemetry, updating every 0.5 seconds with smooth interpolation
-- **Driver leaderboard** showing position, gap to leader, interval, tyre compound and age, tyre history, pit stop count, grid position changes, fastest lap indicator, and investigation/penalty status
-- **Race control messages** - steward decisions, investigations, penalties, track limits, and flag changes displayed in a resizable overlay on the track map
-- **Pit position prediction** (Beta) estimates where a driver would rejoin if they pitted now, with predicted gap ahead and behind, using precomputed pit loss times per circuit with Safety Car and Virtual Safety Car adjustments
-- **Telemetry** for any driver showing speed, throttle, brake, gear, and DRS (2025 and earlier) plotted against track distance
+- **Track map** with real-time car positions from GPS telemetry, updating every 0.5 seconds with smooth interpolation, marshal sector flags, and toggleable corner numbers
+- **Driver leaderboard** showing position, gap to leader, interval, tyre compound and age, tyre history, pit stop count and live pit timer, grid position changes, fastest lap indicator, investigation/penalty status, and sub-1-second interval highlighting
+- **Race control messages** - steward decisions, investigations, penalties, track limits, and flag changes displayed in a draggable overlay on the track map with optional sound notifications
+- **Pit position prediction** estimates where a driver would rejoin if they pitted now, with predicted gap ahead and behind, using precomputed pit loss times per circuit with Safety Car and Virtual Safety Car adjustments
+- **Telemetry** for unlimited drivers showing speed, throttle, brake, gear, and DRS (2025 and earlier) plotted against track distance, with a moveable side panel for 3+ driver comparisons
 - **Picture-in-Picture** mode for a compact floating window with track map, race control, leaderboard, and telemetry
 - **Broadcast sync** - match the replay to a recording of a session, either by uploading a screenshot of the timing tower (using AI vision) or by manually entering gap times
 - **Weather data** including air and track temperature, humidity, wind, and rainfall status
 - **Track status flags** for green, yellow, Safety Car, Virtual Safety Car, and red flag conditions
-- **Playback controls** with 0.5x to 20x speed, skip buttons (5s, 30s, 1m, 5m), lap jumping, and a progress bar
+- **Playback controls** with 0.5x to 20x speed, skip buttons (5s, 30s, 1m, 5m), lap jumping, a progress bar, and red flag countdown with skip-to-restart
 - **Session support** for races, qualifying, sprint qualifying, and practice sessions from 2024 onwards
+- **Full screen mode** hides the session banner and enters browser fullscreen for a distraction-free view
+- **Imperial units** toggle for °F and mph in settings
 - **Passphrase authentication** to optionally restrict access when publicly hosted
 
 ## Architecture

--- a/frontend/src/app/features/page.tsx
+++ b/frontend/src/app/features/page.tsx
@@ -1,13 +1,24 @@
+"use client";
+
 export default function FeaturesPage() {
   return (
     <div className="min-h-screen bg-f1-dark">
       <div className="bg-f1-card border-b border-f1-border">
         <div className="max-w-3xl mx-auto px-6 py-8 flex items-center gap-4">
-          <a href="/" className="text-f1-muted hover:text-white transition-colors">
+          <button
+            onClick={() => {
+              if (window.opener || window.history.length <= 1) {
+                window.close();
+              } else {
+                window.location.href = "/";
+              }
+            }}
+            className="text-f1-muted hover:text-white transition-colors"
+          >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
-          </a>
+          </button>
           <h1 className="text-2xl font-bold text-white">Features</h1>
         </div>
       </div>
@@ -37,66 +48,73 @@ export default function FeaturesPage() {
           </p>
           <div className="space-y-4">
             {/* Position */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Position</span>
               <span className="flex items-center gap-2 flex-shrink-0">
                 <span className="w-6 h-6 flex items-center justify-center rounded bg-f1-red text-white text-sm font-extrabold">1</span>
                 <span className="w-6 text-sm font-extrabold text-white text-right">2</span>
               </span>
-              <span className="text-sm text-f1-text">Current race or session position. The leader is highlighted with a red badge.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Current race or session position. The leader is highlighted with a red badge.</span>
             </div>
 
             {/* Team colour */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Team colour</span>
               <span className="flex items-center gap-1.5 flex-shrink-0">
                 <span className="w-1 h-6 rounded-sm" style={{ backgroundColor: "#FF8000" }} />
                 <span className="w-1 h-6 rounded-sm" style={{ backgroundColor: "#E80020" }} />
               </span>
-              <span className="text-sm text-f1-text">A colour bar next to each driver matching their constructor.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">A colour bar next to each driver matching their constructor.</span>
             </div>
 
             {/* Team abbr */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Team abbr.</span>
               <span className="flex items-center gap-1.5 flex-shrink-0">
                 <span className="text-[10px] font-bold text-f1-muted">MCL</span>
                 <span className="text-[10px] font-bold text-f1-muted">FER</span>
               </span>
-              <span className="text-sm text-f1-text">Three-letter constructor abbreviation. Off by default.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Three-letter constructor abbreviation. Off by default.</span>
             </div>
 
             {/* Gap */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Gap</span>
               <span className="flex items-center gap-2 flex-shrink-0">
                 <span className="text-xs font-bold text-f1-muted">+3.200</span>
                 <span className="text-xs font-bold text-yellow-400">PIT</span>
               </span>
-              <span className="text-sm text-f1-text">Gap to the leader (races) or best lap time (practice/qualifying). Shows &quot;PIT&quot; when in the pit lane.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Gap to the leader (races) or best lap time (practice/qualifying). Shows &quot;PIT&quot; when in the pit lane.</span>
+            </div>
+
+            {/* Last lap time */}
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
+              <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Last lap</span>
+              <span className="text-xs tabular-nums text-f1-muted flex-shrink-0">1:32.456</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">The driver&apos;s most recently completed lap time. Race replay only.</span>
             </div>
 
             {/* Grid delta */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Grid delta</span>
               <span className="flex items-center gap-2 flex-shrink-0">
                 <span className="text-[10px] font-bold text-green-400">&#9650;3</span>
                 <span className="text-[10px] font-bold text-red-400">&#9660;2</span>
               </span>
-              <span className="text-sm text-f1-text">Positions gained or lost compared to the starting grid. Race only.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Positions gained or lost compared to the starting grid. Race only.</span>
             </div>
 
             {/* Pit stops */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Pit stops</span>
               <span className="w-5 h-5 border border-f1-muted rounded-sm flex items-center justify-center text-[10px] font-extrabold text-white flex-shrink-0">
                 2
               </span>
-              <span className="text-sm text-f1-text">Number of pit stops completed so far. Race only.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Number of pit stops completed so far. Race only.</span>
             </div>
 
             {/* Pit prediction */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Pit prediction</span>
               <span className="flex items-center gap-0.5 flex-shrink-0">
                 <img src="/pit-return.png" alt="" className="w-3 h-3 opacity-50 invert" />
@@ -106,39 +124,39 @@ export default function FeaturesPage() {
                 <span className="text-[8px] font-bold text-f1-muted">↑3.2s</span>
                 <span className="text-[8px] font-bold text-f1-muted">↓8.4s</span>
               </span>
-              <span className="text-sm text-f1-text">Predicted return position with gap ahead (top) and gap behind (bottom). Race only.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Predicted return position with gap ahead (top) and gap behind (bottom). Race only.</span>
             </div>
 
             {/* Tyre compound */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Tyre compound</span>
               <span className="flex items-center gap-1.5 flex-shrink-0">
                 <span className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-extrabold leading-none border-2" style={{ borderColor: "#E80020", color: "#E80020" }}>S</span>
                 <span className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-extrabold leading-none border-2" style={{ borderColor: "#FFC800", color: "#FFC800" }}>M</span>
                 <span className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-extrabold leading-none border-2" style={{ borderColor: "#FFFFFF", color: "#FFFFFF" }}>H</span>
               </span>
-              <span className="text-sm text-f1-text">The current tyre compound shown as a colour-coded circle.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">The current tyre compound shown as a colour-coded circle.</span>
             </div>
 
             {/* Tyre age */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Tyre age</span>
               <span className="text-xs font-extrabold text-white flex-shrink-0">12</span>
-              <span className="text-sm text-f1-text">Number of laps on the current set of tyres.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Number of laps on the current set of tyres.</span>
             </div>
 
             {/* Tyre history */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Tyre history</span>
               <span className="flex items-center gap-0.5 flex-shrink-0">
                 <span className="w-3.5 h-3.5 rounded-full flex items-center justify-center text-[7px] font-extrabold leading-none border opacity-50" style={{ borderColor: "#E80020", color: "#E80020" }}>S</span>
                 <span className="w-3.5 h-3.5 rounded-full flex items-center justify-center text-[7px] font-extrabold leading-none border opacity-50" style={{ borderColor: "#FFC800", color: "#FFC800" }}>M</span>
               </span>
-              <span className="text-sm text-f1-text">The last two tyre compounds used, shown as smaller icons. Race only.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">The last two tyre compounds used, shown as smaller icons. Race only.</span>
             </div>
 
             {/* Flags */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
               <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Fastest lap</span>
               <span className="flex items-center gap-1.5 flex-shrink-0">
                 <svg className="w-3.5 h-3.5 text-purple-500" viewBox="0 0 24 24" fill="currentColor">
@@ -146,7 +164,45 @@ export default function FeaturesPage() {
                   <path d="M12 6v7l4.5 2.5" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
                 </svg>
               </span>
-              <span className="text-sm text-f1-text">Purple clock icon shown next to the driver with the fastest lap.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Purple clock icon shown next to the driver with the fastest lap.</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Lap Analysis */}
+        <section className="bg-f1-card border border-f1-border rounded-xl p-6">
+          <div className="flex items-center gap-2 mb-1">
+            <h2 className="text-lg font-bold text-white">Lap Analysis</h2>
+            <span className="px-1.5 py-0.5 text-[9px] font-bold uppercase rounded bg-f1-red/20 text-f1-red leading-none">Beta</span>
+          </div>
+          <p className="text-xs font-bold text-f1-red uppercase tracking-wider mb-3">Race replay only</p>
+          <p className="text-f1-text leading-relaxed mb-3">
+            A dedicated panel for analysing driver pace across the race. On desktop, open it via the
+            &quot;Laps&quot; button on the track map &mdash; the panel slides out to the left. On mobile,
+            it appears as a collapsible section.
+          </p>
+          <p className="text-f1-text leading-relaxed mb-3">
+            Select up to two drivers using the dropdown menus at the top of the panel to compare their
+            lap times side by side.
+          </p>
+          <div className="space-y-4">
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
+              <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Lap chart</span>
+              <span className="flex items-center gap-1 flex-shrink-0">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+              </span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Line chart of lap times over the race. Each driver is coloured by their team. Pit laps are excluded from the line and marked with dots.</span>
+            </div>
+            <div className="flex items-center gap-3 flex-wrap sm:flex-nowrap">
+              <span className="w-24 flex-shrink-0 text-sm font-bold text-f1-muted">Lap list</span>
+              <span className="flex items-center gap-1.5 flex-shrink-0">
+                <span className="text-[10px] tabular-nums text-white">1:32.456</span>
+                <span className="text-[8px] font-bold text-yellow-400">PIT</span>
+                <span className="w-3 h-3 rounded-full flex items-center justify-center text-[6px] font-extrabold leading-none border" style={{ borderColor: "#FF3333", color: "#FF3333" }}>S</span>
+              </span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Full lap-by-lap breakdown showing lap time, tyre compound, and pit stop indicators for each selected driver.</span>
             </div>
           </div>
         </section>
@@ -292,23 +348,23 @@ export default function FeaturesPage() {
           <div className="space-y-3">
             <div className="flex gap-3">
               <span className="w-20 flex-shrink-0 text-sm font-bold text-f1-muted">Speed</span>
-              <span className="text-sm text-f1-text">Vehicle speed in km/h, plotted against track distance.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Vehicle speed in km/h, plotted against track distance.</span>
             </div>
             <div className="flex gap-3">
               <span className="w-20 flex-shrink-0 text-sm font-bold text-f1-muted">Throttle</span>
-              <span className="text-sm text-f1-text">Throttle application from 0-100%.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Throttle application from 0-100%.</span>
             </div>
             <div className="flex gap-3">
               <span className="w-20 flex-shrink-0 text-sm font-bold text-f1-muted">Brake</span>
-              <span className="text-sm text-f1-text">Brake pressure, shown as on/off.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Brake pressure, shown as on/off.</span>
             </div>
             <div className="flex gap-3">
               <span className="w-20 flex-shrink-0 text-sm font-bold text-f1-muted">Gear</span>
-              <span className="text-sm text-f1-text">Current gear selection from 1-8.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">Current gear selection from 1-8.</span>
             </div>
             <div className="flex gap-3">
               <span className="w-20 flex-shrink-0 text-sm font-bold text-f1-muted">DRS</span>
-              <span className="text-sm text-f1-text">DRS activation status. Available for 2025 and earlier sessions. DRS was removed from cars in 2026.</span>
+              <span className="w-full sm:w-auto text-sm text-f1-text">DRS activation status. Available for 2025 and earlier sessions. DRS was removed from cars in 2026.</span>
             </div>
           </div>
         </section>
@@ -405,9 +461,18 @@ export default function FeaturesPage() {
         </section>
 
         <div className="text-center pt-4">
-          <a href="/" className="text-f1-muted hover:text-white transition-colors text-sm">
+          <button
+            onClick={() => {
+              if (window.opener || window.history.length <= 1) {
+                window.close();
+              } else {
+                window.location.href = "/";
+              }
+            }}
+            className="text-f1-muted hover:text-white transition-colors text-sm"
+          >
             Back to session picker
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/app/replay/[year]/[round]/page.tsx
+++ b/frontend/src/app/replay/[year]/[round]/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useApi } from "@/hooks/useApi";
 import { useReplaySocket } from "@/hooks/useReplaySocket";
 import { useSettings } from "@/hooks/useSettings";
 import SessionBanner from "@/components/SessionBanner";
 import TrackCanvas from "@/components/TrackCanvas";
-import Leaderboard from "@/components/Leaderboard";
+import Leaderboard, { type LapEntry } from "@/components/Leaderboard";
 import PlaybackControls from "@/components/PlaybackControls";
 import TelemetryChart from "@/components/TelemetryChart";
 import SyncPhoto from "@/components/SyncPhoto";
 import PiPWindow from "@/components/PiPWindow";
+import LapAnalysisPanel from "@/components/LapAnalysisPanel";
 import type { SectorOverlay } from "@/lib/trackRenderer";
 import { Maximize, Minimize, ArrowUpRight } from "lucide-react";
 
@@ -58,6 +59,10 @@ export default function ReplayPage() {
   const [mobileLeaderboardOpen, setMobileLeaderboardOpen] = useState(true);
   const [mobileTelemetryOpen, setMobileTelemetryOpen] = useState(false);
   const [mobileRcOpen, setMobileRcOpen] = useState(true);
+  const [lapAnalysisOpen, setLapAnalysisOpen] = useState(false);
+  const [mobileLapAnalysisOpen, setMobileLapAnalysisOpen] = useState(false);
+  // Force telemetry to bottom when lap analysis panel is open to avoid squashing the track map
+  const effectiveTelemetryPosition = lapAnalysisOpen && telemetryPosition === "left" ? "bottom" : telemetryPosition;
   const [leaderboardScale, setLeaderboardScale] = useState(1);
   const [pipTrackOpen, setPipTrackOpen] = useState(true);
   const [pipTelemetryOpen, setPipTelemetryOpen] = useState(false);
@@ -139,6 +144,29 @@ export default function ReplayPage() {
     `/api/sessions/${year}/${round}/track?type=${sessionType}`,
   );
 
+  // Fetch lap data for last lap time column (race/sprint only)
+  const { data: lapsResponse } = useApi<{ laps: LapEntry[] }>(
+    sessionType === "R" || sessionType === "S"
+      ? `/api/sessions/${year}/${round}/laps?type=${sessionType}`
+      : null,
+  );
+
+  // Build lookup: driver -> lap_number -> lap_time
+  const lapData = useMemo(() => {
+    if (!lapsResponse?.laps) return undefined;
+    const map = new Map<string, Map<number, string>>();
+    for (const lap of lapsResponse.laps) {
+      if (!lap.lap_time) continue;
+      let driverMap = map.get(lap.driver);
+      if (!driverMap) {
+        driverMap = new Map();
+        map.set(lap.driver, driverMap);
+      }
+      driverMap.set(lap.lap_number, lap.lap_time);
+    }
+    return map;
+  }, [lapsResponse]);
+
   const replay = useReplaySocket(year, round, sessionType);
 
   // RC sound notification
@@ -168,7 +196,7 @@ export default function ReplayPage() {
       setTelemetryHeight(telemetryPanelRef.current.offsetHeight);
       setTelemetryWidth(telemetryPanelRef.current.offsetWidth);
     }
-  }, [selectedDrivers.length, showTelemetry, telemetryPosition]);
+  }, [selectedDrivers.length, showTelemetry, effectiveTelemetryPosition]);
 
   const isLoading = sessionLoading || trackLoading;
   const dataError = sessionError || trackError;
@@ -241,12 +269,13 @@ export default function ReplayPage() {
   })();
 
   // Calculate leaderboard width based on active columns
-  const leaderboardWidth = (() => {
+  const leaderboardWidthFull = (() => {
     let w = 106; // base: position(24) + team bar(12) + driver(30) + flags(16) + padding(16) + right padding(8)
     if (settings.showTeamAbbr) w += 28;
     if (!isRace) w += 18; // pit indicator (P box + margin)
     if (isRace && settings.showGridChange) w += 24;
     if (!isRace && settings.showBestLapTime) w += 60; // best lap time column
+    if (isRace && settings.showLastLapTime) w += 60; // last lap time column
     if (settings.showGapToLeader) w += 56;
     if (isQualifying && settings.showSectors) w += 36; // sector indicators (28 + 8 margin)
     if (isRace && settings.showPitStops) w += 24;
@@ -257,6 +286,10 @@ export default function ReplayPage() {
     if (isRace && settings.showPitPrediction && settings.showPitFreeAir) w += 36; // pit gaps (ahead/behind)
     return w;
   })();
+
+  // On mobile, auto-hide team abbreviation if columns overflow the screen
+  const mobileTeamAbbrHidden = isMobile && settings.showTeamAbbr && leaderboardWidthFull > (typeof window !== "undefined" ? window.innerWidth : 400);
+  const leaderboardWidth = mobileTeamAbbrHidden ? leaderboardWidthFull - 28 : leaderboardWidthFull;
 
   return (
     <div className="h-dvh flex flex-col bg-f1-dark overflow-hidden" style={{ paddingTop: "env(safe-area-inset-top)" }}>
@@ -271,13 +304,48 @@ export default function ReplayPage() {
           settings={settings}
           onSettingChange={updateSetting}
           weather={weather}
+          mobileTeamAbbrHidden={mobileTeamAbbrHidden}
         />
       )}
 
       {/* Main content */}
-      <div className="flex-1 flex flex-col sm:flex-row min-h-0 overflow-y-auto sm:overflow-hidden pb-16 sm:pb-0">
+      <div className="flex-1 flex flex-col sm:flex-row min-h-0 overflow-y-auto sm:overflow-hidden pb-20 sm:pb-0">
+        {/* Race Control section - mobile only, above track map */}
+        <div className="sm:hidden">
+          <button
+            onClick={() => setMobileRcOpen(!mobileRcOpen)}
+            className="w-full flex items-center justify-between px-3 py-2 bg-f1-card border-b border-f1-border"
+          >
+            <span className="text-[11px] font-bold text-f1-muted uppercase tracking-wider">Race Control</span>
+            <svg className={`w-4 h-4 text-f1-muted transition-transform ${mobileRcOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          {mobileRcOpen && (() => {
+            const latest = (replay.frame?.rc_messages || [])[0];
+            if (!latest) return <p className="text-f1-muted text-xs px-3 py-2">No messages yet</p>;
+            const upper = latest.message.toUpperCase();
+            const isPenalty = upper.includes("PENALTY") && !upper.includes("NO FURTHER");
+            const isInvestigation = upper.includes("INVESTIGATION") || upper.includes("NOTED");
+            const isCleared = upper.includes("NO FURTHER") || upper.includes("NO INVESTIGATION");
+            return (
+              <div className="px-3 py-2 bg-f1-card border-b border-f1-border">
+                <div className="flex items-start gap-2">
+                  <div className={`w-1.5 h-1.5 rounded-full mt-1.5 flex-shrink-0 ${
+                    isPenalty ? "bg-red-500" : isInvestigation ? "bg-orange-400" : isCleared ? "bg-green-500" : "bg-f1-muted"
+                  }`} />
+                  <div className="min-w-0">
+                    <p className="text-[11px] text-white leading-tight">{latest.message}</p>
+                    {latest.lap && <span className="text-[9px] text-f1-muted">Lap {latest.lap}</span>}
+                  </div>
+                </div>
+              </div>
+            );
+          })()}
+        </div>
+
         {/* Track section */}
-        <div className={`sm:flex-1 ${!isMobile && showTelemetry && selectedDrivers.length > 2 ? `flex ${telemetryPosition === "left" ? "flex-row" : "flex-col"} min-h-0` : "relative"}`}>
+        <div className={`sm:flex-1 ${!isMobile && showTelemetry && selectedDrivers.length > 2 ? `flex ${effectiveTelemetryPosition === "left" ? "flex-row" : "flex-col"} min-h-0` : "relative"}`}>
           {/* Mobile section header */}
           {isMobile && (
             <button
@@ -497,6 +565,47 @@ export default function ReplayPage() {
                 </div>
               )}
 
+              {/* Sector overlay controls - mobile qualifying only */}
+              {isMobile && isQualifying && trackData?.sector_boundaries && (
+                <div className="absolute bottom-2 left-2 right-2 z-20 flex items-center gap-1">
+                  {showSectorOverlay && selectedDrivers.length > 0 && (
+                    <div className="flex items-center gap-1 overflow-x-auto">
+                      {selectedDrivers.map((abbr) => {
+                        const drv = drivers.find((d) => d.abbr === abbr);
+                        const isActive = sectorFocusDriver === abbr;
+                        return (
+                          <button
+                            key={abbr}
+                            onClick={() => setSectorFocusDriver(isActive ? null : abbr)}
+                            className={`flex-shrink-0 px-1.5 py-1 border rounded text-[10px] font-bold transition-colors ${
+                              isActive
+                                ? "bg-purple-500/20 border-purple-500/50 text-purple-300"
+                                : "bg-f1-card/90 border-f1-border text-f1-muted backdrop-blur-sm"
+                            }`}
+                          >
+                            <span className="inline-block w-1.5 h-1.5 rounded-full mr-1" style={{ backgroundColor: drv?.color }} />
+                            {abbr}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+                  {showSectorOverlay && selectedDrivers.length === 0 && (
+                    <span className="text-[10px] text-f1-muted">Select a driver to view sectors</span>
+                  )}
+                  <button
+                    onClick={() => setShowSectorOverlay(!showSectorOverlay)}
+                    className={`flex-shrink-0 ml-auto px-2 py-1 border rounded text-[10px] font-bold transition-colors ${
+                      showSectorOverlay
+                        ? "bg-purple-500/20 border-purple-500/50 text-purple-300"
+                        : "bg-f1-card/90 border-f1-border text-f1-muted backdrop-blur-sm"
+                    }`}
+                  >
+                    Sectors
+                  </button>
+                </div>
+              )}
+
               {/* Fullscreen toggle moved to PlaybackControls */}
 
               {/* Telemetry overlay - desktop only, bottom-left (1-2 drivers) */}
@@ -528,6 +637,23 @@ export default function ReplayPage() {
                   Show Telemetry
                 </button>
               )}
+
+              {/* Lap Analysis floating button - desktop only, bottom-right */}
+              {!isMobile && isRace && lapsResponse?.laps && (
+                <button
+                  onClick={() => setLapAnalysisOpen(!lapAnalysisOpen)}
+                  className={`absolute bottom-2 right-3 z-20 flex items-center gap-1 px-2 py-1 rounded text-xs font-bold transition-colors ${
+                    lapAnalysisOpen
+                      ? "bg-f1-red text-white"
+                      : "bg-f1-card/90 border border-f1-border text-f1-muted hover:text-white backdrop-blur-sm"
+                  }`}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                  </svg>
+                  Laps
+                </button>
+              )}
             </div>
           )}
 
@@ -535,22 +661,26 @@ export default function ReplayPage() {
           {!isMobile && showTelemetry && selectedDrivers.length > 2 && (
             <div
               className={`flex-shrink-0 ${
-                telemetryPosition === "left"
+                effectiveTelemetryPosition === "left"
                   ? "h-full bg-f1-card border-r border-f1-border order-first px-3 py-2 overflow-y-auto overflow-x-hidden"
                   : "border-t border-f1-border py-1 flex overflow-hidden"
               }`}
-              style={telemetryPosition === "left" && rcPinned && telemetryWidth > 0 ? { width: telemetryWidth + 24 } : undefined}
+              style={effectiveTelemetryPosition === "left" && rcPinned && telemetryWidth > 0 ? { width: telemetryWidth + 24 } : undefined}
             >
-              <div ref={telemetryPanelRef} className={telemetryPosition === "bottom" ? "inline-block bg-f1-card px-3 pt-1 flex-shrink-0" : ""}>
+              <div ref={telemetryPanelRef} className={effectiveTelemetryPosition === "bottom" ? "inline-block bg-f1-card px-3 pt-1 flex-shrink-0" : ""}>
                 <div className="flex items-center gap-2 mb-1">
                   <span className="text-[10px] font-bold text-f1-muted uppercase">Telemetry</span>
-                  <button
-                    onClick={() => setTelemetryPosition(telemetryPosition === "left" ? "bottom" : "left")}
-                    className="px-1.5 py-0.5 text-[9px] font-bold text-f1-muted hover:text-white border border-f1-border rounded transition-colors"
-                    title={telemetryPosition === "left" ? "Move to bottom" : "Move to left"}
-                  >
-                    {telemetryPosition === "left" ? "Move to bottom" : "Move to left"}
-                  </button>
+                  {lapAnalysisOpen ? (
+                    <span className="text-[9px] text-f1-muted italic">Shown at bottom while Lap Analysis is open</span>
+                  ) : (
+                    <button
+                      onClick={() => setTelemetryPosition(telemetryPosition === "left" ? "bottom" : "left")}
+                      className="px-1.5 py-0.5 text-[9px] font-bold text-f1-muted hover:text-white border border-f1-border rounded transition-colors"
+                      title={telemetryPosition === "left" ? "Move to bottom" : "Move to left"}
+                    >
+                      {telemetryPosition === "left" ? "Move to bottom" : "Move to left"}
+                    </button>
+                  )}
                   <button
                     onClick={() => setShowTelemetry(false)}
                     className="px-1.5 py-0.5 text-[9px] font-bold text-f1-muted hover:text-white border border-f1-border rounded transition-colors ml-auto"
@@ -569,7 +699,7 @@ export default function ReplayPage() {
               {/* Race Control in panel: show button or pinned messages */}
               {!rcPinned && (
                 <div className={`flex items-center justify-center ${
-                  telemetryPosition === "bottom"
+                  effectiveTelemetryPosition === "bottom"
                     ? "border-l border-f1-border px-4"
                     : "border-t border-f1-border py-2 mt-2"
                 }`}>
@@ -584,11 +714,11 @@ export default function ReplayPage() {
               {rcPinned && (
                 <div
                   className={`bg-f1-card ${
-                    telemetryPosition === "bottom"
+                    effectiveTelemetryPosition === "bottom"
                       ? "border-l border-f1-border px-3 pt-1 flex-1 overflow-hidden flex flex-col"
                     : "border-t border-f1-border px-3 py-2 mt-2"
                   }`}
-                  style={telemetryPosition === "bottom" && telemetryHeight > 0 ? { maxHeight: telemetryHeight } : undefined}
+                  style={effectiveTelemetryPosition === "bottom" && telemetryHeight > 0 ? { maxHeight: telemetryHeight } : undefined}
                 >
                   <div className="flex items-center justify-between mb-1">
                     <span className="text-[10px] font-bold text-f1-muted uppercase">Race Control</span>
@@ -630,40 +760,6 @@ export default function ReplayPage() {
           )}
         </div>
 
-        {/* Race Control section - mobile only */}
-        <div className="sm:hidden">
-          <button
-            onClick={() => setMobileRcOpen(!mobileRcOpen)}
-            className="w-full flex items-center justify-between px-3 py-2 bg-f1-card border-b border-f1-border"
-          >
-            <span className="text-[11px] font-bold text-f1-muted uppercase tracking-wider">Race Control</span>
-            <svg className={`w-4 h-4 text-f1-muted transition-transform ${mobileRcOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
-          </button>
-          {mobileRcOpen && (() => {
-            const latest = (replay.frame?.rc_messages || [])[0];
-            if (!latest) return <p className="text-f1-muted text-xs px-3 py-2">No messages yet</p>;
-            const upper = latest.message.toUpperCase();
-            const isPenalty = upper.includes("PENALTY") && !upper.includes("NO FURTHER");
-            const isInvestigation = upper.includes("INVESTIGATION") || upper.includes("NOTED");
-            const isCleared = upper.includes("NO FURTHER") || upper.includes("NO INVESTIGATION");
-            return (
-              <div className="px-3 py-2 bg-f1-card border-b border-f1-border">
-                <div className="flex items-start gap-2">
-                  <div className={`w-1.5 h-1.5 rounded-full mt-1.5 flex-shrink-0 ${
-                    isPenalty ? "bg-red-500" : isInvestigation ? "bg-orange-400" : isCleared ? "bg-green-500" : "bg-f1-muted"
-                  }`} />
-                  <div className="min-w-0">
-                    <p className="text-[11px] text-white leading-tight">{latest.message}</p>
-                    {latest.lap && <span className="text-[9px] text-f1-muted">Lap {latest.lap}</span>}
-                  </div>
-                </div>
-              </div>
-            );
-          })()}
-        </div>
-
         {/* Telemetry section - mobile only, collapsible like leaderboard */}
         <div className="sm:hidden">
           <button
@@ -689,33 +785,69 @@ export default function ReplayPage() {
           )}
         </div>
 
-        {/* Leaderboard section */}
+        {/* Leaderboard section (with optional lap analysis panel on desktop) */}
         {settings.showLeaderboard && (
-          <div className={`flex-shrink-0 ${isMobile ? "" : "border-l"} border-f1-border`} style={{ width: isMobile ? "100%" : Math.ceil(leaderboardWidth * leaderboardScale) }}>
-            {/* Mobile section header */}
-            {isMobile && (
-              <button
-                onClick={() => setMobileLeaderboardOpen(!mobileLeaderboardOpen)}
-                className="w-full flex items-center justify-between px-3 py-2 bg-f1-card border-b border-f1-border"
-              >
-                <span className="text-[11px] font-bold text-f1-muted uppercase tracking-wider">Leaderboard</span>
-                <svg className={`w-4 h-4 text-f1-muted transition-transform ${mobileLeaderboardOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-                </svg>
-              </button>
+          <div className={`flex-shrink-0 flex ${isMobile ? "" : "border-l"} border-f1-border`} style={{ width: isMobile ? "100%" : undefined }}>
+            {/* Lap Analysis Panel - desktop only, left of leaderboard */}
+            {!isMobile && isRace && lapAnalysisOpen && lapsResponse?.laps && (
+              <div className="w-[300px] h-full border-r border-f1-border overflow-hidden flex-shrink-0">
+                <LapAnalysisPanel laps={lapsResponse.laps} drivers={drivers} currentLap={replay.frame?.lap || 0} onClose={() => setLapAnalysisOpen(false)} />
+              </div>
             )}
 
-            {(!isMobile || mobileLeaderboardOpen) && (
-              <Leaderboard
-                drivers={drivers}
-                highlightedDrivers={selectedDrivers}
-                onDriverClick={handleDriverClick}
-                settings={settings}
-                currentTime={replay.frame?.timestamp || 0}
-                isRace={isRace}
-                isQualifying={isQualifying}
-                onScaleChange={setLeaderboardScale}
-              />
+            <div style={{ width: isMobile ? "100%" : Math.ceil(leaderboardWidth * leaderboardScale) }}>
+              {/* Mobile section header */}
+              {isMobile && (
+                <button
+                  onClick={() => setMobileLeaderboardOpen(!mobileLeaderboardOpen)}
+                  className="w-full flex items-center justify-between px-3 py-2 bg-f1-card border-b border-f1-border"
+                >
+                  <span className="text-[11px] font-bold text-f1-muted uppercase tracking-wider">Leaderboard</span>
+                  <svg className={`w-4 h-4 text-f1-muted transition-transform ${mobileLeaderboardOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </button>
+              )}
+
+              {(!isMobile || mobileLeaderboardOpen) && (
+                <Leaderboard
+                  drivers={drivers}
+                  highlightedDrivers={selectedDrivers}
+                  onDriverClick={handleDriverClick}
+                  settings={settings}
+                  currentTime={replay.frame?.timestamp || 0}
+                  isRace={isRace}
+                  isQualifying={isQualifying}
+                  onScaleChange={setLeaderboardScale}
+                  lapData={lapData}
+                  currentLap={replay.frame?.lap || 0}
+                  mobileTeamAbbrHidden={mobileTeamAbbrHidden}
+                />
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Lap Analysis section - mobile only, below leaderboard */}
+        {isMobile && isRace && lapsResponse?.laps && (
+          <div className="sm:hidden border-t border-f1-border" ref={(el) => {
+            if (el && mobileLapAnalysisOpen) {
+              setTimeout(() => el.scrollIntoView({ behavior: "smooth", block: "start" }), 100);
+            }
+          }}>
+            <button
+              onClick={() => setMobileLapAnalysisOpen(!mobileLapAnalysisOpen)}
+              className="w-full flex items-center justify-between px-3 py-3 bg-f1-card border-b border-f1-border min-h-[44px]"
+            >
+              <span className="text-[11px] font-bold text-f1-muted uppercase tracking-wider">Lap Analysis</span>
+              <svg className={`w-4 h-4 text-f1-muted transition-transform ${mobileLapAnalysisOpen ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {mobileLapAnalysisOpen && (
+              <div className="bg-f1-card">
+                <LapAnalysisPanel laps={lapsResponse.laps} drivers={drivers} currentLap={replay.frame?.lap || 0} />
+              </div>
             )}
           </div>
         )}
@@ -899,7 +1031,9 @@ export default function ReplayPage() {
                     isRace={isRace}
                     isQualifying={isQualifying}
                     compact
-                  />
+                    lapData={lapData}
+                    currentLap={replay.frame?.lap || 0}
+                      />
                 </div>
               )}
             </div>

--- a/frontend/src/components/LapAnalysisPanel.tsx
+++ b/frontend/src/components/LapAnalysisPanel.tsx
@@ -1,0 +1,595 @@
+"use client";
+
+import { useState, useMemo, useRef, useEffect } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceDot,
+  ReferenceArea,
+} from "recharts";
+import { ReplayDriver } from "@/hooks/useReplaySocket";
+import { LapEntry } from "@/components/Leaderboard";
+import { TYRE_COLORS, TYRE_SHORT } from "@/lib/constants";
+
+interface Props {
+  laps: LapEntry[];
+  drivers: ReplayDriver[];
+  currentLap: number;
+  onClose?: () => void;
+}
+
+function parseLapTime(timeStr: string): number | null {
+  if (!timeStr) return null;
+  const parts = timeStr.split(":");
+  if (parts.length === 2) {
+    return parseInt(parts[0]) * 60 + parseFloat(parts[1]);
+  }
+  const val = parseFloat(parts[0]);
+  return isNaN(val) ? null : val;
+}
+
+function formatSeconds(secs: number): string {
+  const mins = Math.floor(secs / 60);
+  const remainder = secs - mins * 60;
+  return `${mins}:${remainder.toFixed(3).padStart(6, "0")}`;
+}
+
+function DriverDropdown({ value, onChange, drivers, placeholder, getColor }: {
+  value: string | null;
+  onChange: (abbr: string | null) => void;
+  drivers: ReplayDriver[];
+  placeholder: string;
+  getColor: (abbr: string) => string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const selected = drivers.find((d) => d.abbr === value);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-2 bg-f1-dark border border-f1-border rounded px-2 py-1.5 text-left hover:border-f1-muted transition-colors"
+      >
+        {selected ? (
+          <>
+            <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: getColor(selected.abbr) }} />
+            <span className="text-xs font-bold text-white">{selected.abbr}</span>
+            <span className="text-[10px] text-f1-muted truncate">{selected.team}</span>
+          </>
+        ) : (
+          <span className="text-xs text-f1-muted">{placeholder}</span>
+        )}
+        <svg className={`w-3 h-3 ml-auto text-f1-muted flex-shrink-0 transition-transform ${open ? "rotate-180" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-f1-dark border border-f1-border rounded shadow-xl z-50 max-h-[200px] overflow-y-auto">
+          {value && (
+            <button
+              onClick={() => { onChange(null); setOpen(false); }}
+              className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-f1-muted hover:bg-white/5 transition-colors"
+            >
+              Clear
+            </button>
+          )}
+          {drivers.map((d) => (
+            <button
+              key={d.abbr}
+              onClick={() => { onChange(d.abbr); setOpen(false); }}
+              className={`w-full flex items-center gap-2 px-2 py-1.5 hover:bg-white/5 transition-colors ${
+                d.abbr === value ? "bg-white/10" : ""
+              }`}
+            >
+              <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: d.color }} />
+              <span className="text-[10px] font-bold text-f1-muted w-4 text-right">{d.position}</span>
+              <span className="text-xs font-bold text-white">{d.abbr}</span>
+              <span className="text-[10px] text-f1-muted truncate">{d.team}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const LAP_RANGES = [
+  { label: "All", value: 0 },
+  { label: "Last 5", value: 5 },
+  { label: "Last 10", value: 10 },
+  { label: "Last 20", value: 20 },
+] as const;
+
+export default function LapAnalysisPanel({ laps, drivers, currentLap, onClose }: Props) {
+  const [selectedDrivers, setSelectedDrivers] = useState<[string | null, string | null]>([null, null]);
+  const [lapRange, setLapRange] = useState<number>(0); // 0 = all
+
+  const sortedDrivers = useMemo(
+    () => [...drivers].sort((a, b) => (a.position ?? 999) - (b.position ?? 999)),
+    [drivers],
+  );
+
+  // Build per-driver lap arrays
+  const driverLaps = useMemo(() => {
+    const map = new Map<string, LapEntry[]>();
+    for (const lap of laps) {
+      let arr = map.get(lap.driver);
+      if (!arr) {
+        arr = [];
+        map.set(lap.driver, arr);
+      }
+      arr.push(lap);
+    }
+    // Sort each by lap number
+    for (const arr of map.values()) {
+      arr.sort((a, b) => a.lap_number - b.lap_number);
+    }
+    return map;
+  }, [laps]);
+
+  // Chart data: merged by lap number for up to 2 drivers
+  const { chartData, slowBands, pitBands, yDomain } = useMemo(() => {
+    const active = selectedDrivers.filter((d): d is string => d !== null);
+    if (active.length === 0) return { chartData: [], slowBands: [], pitBands: [], yDomain: [0, 0] as [number, number] };
+
+    const maxLap = Math.max(...active.map((d) => {
+      const dl = driverLaps.get(d);
+      if (!dl) return 0;
+      const filtered = dl.filter((l) => l.lap_number <= currentLap);
+      return filtered.length > 0 ? filtered[filtered.length - 1].lap_number : 0;
+    }));
+
+    // Collect pit laps across all active drivers
+    const pitLapSet = new Set<number>();
+    for (const d of active) {
+      const dl = driverLaps.get(d) || [];
+      for (const l of dl) {
+        if (l.pit_in || l.pit_out) pitLapSet.add(l.lap_number);
+      }
+    }
+
+    // First pass: collect all clean lap times to compute median (skip lap 1 and pit laps)
+    const allCleanTimes: number[] = [];
+    for (let lap = 2; lap <= maxLap; lap++) {
+      if (pitLapSet.has(lap)) continue;
+      for (const d of active) {
+        const dl = driverLaps.get(d);
+        const entry = dl?.find((l) => l.lap_number === lap);
+        if (entry?.lap_time && lap <= currentLap) {
+          const secs = parseLapTime(entry.lap_time);
+          if (secs !== null) allCleanTimes.push(secs);
+        }
+      }
+    }
+    allCleanTimes.sort((a, b) => a - b);
+    const median = allCleanTimes.length > 0 ? allCleanTimes[Math.floor(allCleanTimes.length / 2)] : 0;
+    const slowThreshold = median * 1.07; // 7% slower than median = likely SC/VSC/slow lap
+
+    // Second pass: build chart data, detect slow laps
+    const slowLapSet = new Set<number>();
+    let minTime = Infinity;
+    let maxTime = 0;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: Record<string, any>[] = [];
+    for (let lap = 1; lap <= maxLap; lap++) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const point: Record<string, any> = { lap };
+      const isPit = pitLapSet.has(lap);
+      const isFirstLap = lap === 1;
+
+      // Check if this lap is slow for any driver (also flag lap 1)
+      let isSlow = false;
+      if (!isPit && !isFirstLap) {
+        for (const d of active) {
+          const dl = driverLaps.get(d);
+          const entry = dl?.find((l) => l.lap_number === lap);
+          if (entry?.lap_time && lap <= currentLap) {
+            const secs = parseLapTime(entry.lap_time);
+            if (secs !== null && secs > slowThreshold) { isSlow = true; break; }
+          }
+        }
+      }
+      if (isSlow) slowLapSet.add(lap);
+
+      // Store band type for tooltip
+      point._bandType = isPit ? "pit" : isSlow ? "slow" : isFirstLap ? "lap1" : null;
+      // Invisible hover target — must be within Y domain so it doesn't distort the axis
+      point._hover = null;
+
+      // Exclude pit laps, slow laps, and lap 1 from the line + Y-axis scaling
+      const excludeFromLine = isPit || isSlow || isFirstLap;
+
+      for (const d of active) {
+        const dl = driverLaps.get(d);
+        const entry = dl?.find((l) => l.lap_number === lap);
+        // Always store the actual time for tooltip display
+        if (entry?.lap_time && lap <= currentLap) {
+          const secs = parseLapTime(entry.lap_time);
+          if (secs !== null) {
+            point[`_time_${d}`] = secs;
+          }
+        }
+        if (entry?.lap_time && !excludeFromLine && lap <= currentLap) {
+          const secs = parseLapTime(entry.lap_time);
+          if (secs !== null) {
+            point[d] = secs;
+            if (secs < minTime) minTime = secs;
+            if (secs > maxTime) maxTime = secs;
+          } else {
+            point[d] = null;
+          }
+        } else {
+          point[d] = null;
+        }
+      }
+      data.push(point);
+    }
+
+    // Build contiguous bands for slow laps and pit laps
+    function buildBands(lapSet: Set<number>): { x1: number; x2: number }[] {
+      const sorted = Array.from(lapSet).sort((a, b) => a - b);
+      const bands: { x1: number; x2: number }[] = [];
+      let i = 0;
+      while (i < sorted.length) {
+        const start = sorted[i];
+        let end = start;
+        while (i + 1 < sorted.length && sorted[i + 1] === end + 1) {
+          i++;
+          end = sorted[i];
+        }
+        bands.push({ x1: start - 0.5, x2: end + 0.5 });
+        i++;
+      }
+      return bands;
+    }
+
+    // Set _hover to midpoint of Y range so tooltip triggers on every lap without distorting Y axis
+    const mid = minTime < Infinity ? (minTime + maxTime) / 2 : 0;
+    for (const point of data) {
+      point._hover = mid;
+    }
+
+    const padding = (maxTime - minTime) * 0.1 || 2;
+    return {
+      chartData: data,
+      slowBands: buildBands(slowLapSet),
+      pitBands: buildBands(pitLapSet),
+      yDomain: [Math.max(0, minTime - padding), maxTime + padding] as [number, number],
+    };
+  }, [selectedDrivers, driverLaps, currentLap]);
+
+  const activeDrivers = selectedDrivers.filter((d): d is string => d !== null);
+
+  // Filter chart data by lap range
+  const { visibleChartData, visibleYDomain, visibleSlowBands, visiblePitBands } = useMemo(() => {
+    if (lapRange === 0 || chartData.length === 0) {
+      return { visibleChartData: chartData, visibleYDomain: yDomain, visibleSlowBands: slowBands, visiblePitBands: pitBands };
+    }
+    const minLap = Math.max(1, currentLap - lapRange);
+    const filtered = chartData.filter((d) => (d.lap as number) >= minLap && (d.lap as number) <= currentLap);
+
+    // Recompute Y domain for visible range
+    let min = Infinity;
+    let max = 0;
+    for (const point of filtered) {
+      for (const d of activeDrivers) {
+        const v = point[d];
+        if (v !== null && typeof v === "number") {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+      }
+    }
+    const padding = (max - min) * 0.1 || 2;
+    const vYDomain: [number, number] = min < Infinity ? [Math.max(0, min - padding), max + padding] : yDomain;
+
+    // Filter bands to visible range
+    const filterBands = (bands: { x1: number; x2: number }[]) =>
+      bands.filter((b) => b.x2 >= minLap && b.x1 <= currentLap)
+        .map((b) => ({ x1: Math.max(b.x1, minLap), x2: Math.min(b.x2, currentLap) }));
+
+    return {
+      visibleChartData: filtered,
+      visibleYDomain: vYDomain,
+      visibleSlowBands: filterBands(slowBands),
+      visiblePitBands: filterBands(pitBands),
+    };
+  }, [chartData, yDomain, slowBands, pitBands, lapRange, currentLap, activeDrivers]);
+
+  const SECOND_DRIVER_COLOR = "#06B6D4"; // cyan to contrast any team colour
+
+  function getDriverColor(abbr: string): string {
+    const teamColor = drivers.find((d) => d.abbr === abbr)?.color || "#888";
+    // If two drivers selected and they share a team colour, use a distinct colour for the second
+    if (activeDrivers.length === 2 && abbr === activeDrivers[1]) {
+      const firstColor = drivers.find((d) => d.abbr === activeDrivers[0])?.color || "#888";
+      if (firstColor.toLowerCase() === teamColor.toLowerCase()) {
+        return SECOND_DRIVER_COLOR;
+      }
+    }
+    return teamColor;
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-f1-card overflow-hidden">
+      {/* Header - only shown on desktop (mobile has its own collapsible header) */}
+      {onClose && (
+        <div className="px-3 py-2 border-b border-f1-border flex-shrink-0 flex items-center justify-between">
+          <span className="text-[10px] font-bold text-f1-muted uppercase tracking-wider">Lap Analysis</span>
+          <button onClick={onClose} className="px-2 py-0.5 bg-f1-card/90 border border-f1-border rounded text-[9px] font-bold text-f1-muted hover:text-white transition-colors">
+            Hide
+          </button>
+        </div>
+      )}
+
+      {/* Driver selectors */}
+      <div className="px-3 py-2 space-y-1.5 flex-shrink-0 border-b border-f1-border">
+        <DriverDropdown
+          value={selectedDrivers[0]}
+          onChange={(abbr) => setSelectedDrivers((prev) => [abbr, prev[1]])}
+          drivers={sortedDrivers}
+          placeholder="Select driver..."
+          getColor={getDriverColor}
+        />
+        <DriverDropdown
+          value={selectedDrivers[1]}
+          onChange={(abbr) => setSelectedDrivers((prev) => [prev[0], abbr])}
+          drivers={sortedDrivers}
+          placeholder="Compare with..."
+          getColor={getDriverColor}
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto min-h-0">
+        {activeDrivers.length === 0 ? (
+          <div className="px-3 py-6 text-center text-xs text-f1-muted">
+            Select a driver to view lap times
+          </div>
+        ) : (
+          <>
+            {/* Lap range toggle + Chart */}
+            {chartData.length > 0 && (
+              <div className="px-2 pt-2 pb-1 flex-shrink-0">
+                <div className="flex items-center gap-1 mb-2">
+                  {LAP_RANGES.map(({ label, value }) => (
+                    <button
+                      key={value}
+                      onClick={() => setLapRange(value)}
+                      className={`px-2 py-0.5 rounded text-[9px] font-bold transition-colors ${
+                        lapRange === value
+                          ? "bg-f1-red text-white"
+                          : "bg-f1-dark border border-f1-border text-f1-muted hover:text-white"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <ResponsiveContainer width="100%" height={170}>
+                  <LineChart data={visibleChartData} margin={{ top: 5, right: 5, left: -10, bottom: 5 }}>
+                    <XAxis
+                      dataKey="lap"
+                      type="number"
+                      domain={["dataMin", "dataMax"]}
+                      tick={{ fill: "#6B7280", fontSize: 7 }}
+                      tickLine={false}
+                      axisLine={{ stroke: "#374151" }}
+                      allowDecimals={false}
+                      ticks={visibleChartData.map((d) => d.lap as number)}
+                    />
+                    <YAxis
+                      domain={visibleYDomain}
+                      allowDataOverflow={true}
+                      tick={{ fill: "#6B7280", fontSize: 9 }}
+                      tickLine={false}
+                      axisLine={{ stroke: "#374151" }}
+                      tickFormatter={(v: number) => formatSeconds(v)}
+                    />
+                    <Tooltip
+                      content={({ active, payload, label }) => {
+                        if (!active || !payload || payload.length === 0) return null;
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        const point = payload[0]?.payload as Record<string, any> | undefined;
+                        if (!point) return null;
+                        const bandType = point._bandType as string | null;
+                        const bandLabel = bandType === "pit" ? "Pit Stop" : bandType === "slow" ? "Yellow Flag / Slow Lap" : bandType === "lap1" ? "Formation / Lap 1" : null;
+                        return (
+                          <div className="bg-[#1A1A26] border border-f1-border rounded-md px-2.5 py-1.5 text-[11px] shadow-xl">
+                            <div className="font-bold text-white mb-0.5">Lap {label}</div>
+                            {bandLabel && (
+                              <div className={`font-bold mb-0.5 ${bandType === "slow" ? "text-yellow-400" : "text-f1-muted"}`}>
+                                {bandLabel}
+                              </div>
+                            )}
+                            {activeDrivers.map((abbr) => {
+                              const time = point[`_time_${abbr}`];
+                              const lineVal = point[abbr];
+                              return (
+                                <div key={abbr} className="flex items-center gap-1.5">
+                                  <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: getDriverColor(abbr) }} />
+                                  <span className="text-f1-muted">{abbr}:</span>
+                                  <span className={lineVal != null ? "text-white" : "text-f1-muted"}>
+                                    {time != null ? formatSeconds(time) : "—"}
+                                  </span>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        );
+                      }}
+                    />
+                    {/* Slow lap bands (safety car / yellow flag) */}
+                    {visibleSlowBands.map((band, i) => (
+                      <ReferenceArea
+                        key={`slow-${i}`}
+                        x1={band.x1}
+                        x2={band.x2}
+                        y1={visibleYDomain[0]}
+                        y2={visibleYDomain[1]}
+                        fill="#EAB308"
+                        fillOpacity={0.15}
+                        stroke="#EAB308"
+                        strokeOpacity={0.3}
+                        strokeDasharray="3 3"
+                        ifOverflow="extendDomain"
+                      />
+                    ))}
+                    {/* Pit lap bands */}
+                    {visiblePitBands.map((band, i) => (
+                      <ReferenceArea
+                        key={`pit-${i}`}
+                        x1={band.x1}
+                        x2={band.x2}
+                        y1={visibleYDomain[0]}
+                        y2={visibleYDomain[1]}
+                        fill="#FFFFFF"
+                        fillOpacity={0.06}
+                        stroke="#6B7280"
+                        strokeOpacity={0.3}
+                        strokeDasharray="3 3"
+                        ifOverflow="extendDomain"
+                      />
+                    ))}
+                    {/* Invisible line to enable tooltip on every lap including banded laps */}
+                    <Line
+                      type="monotone"
+                      dataKey="_hover"
+                      stroke="transparent"
+                      strokeWidth={0}
+                      dot={false}
+                      activeDot={false}
+                      name="_hover"
+                      legendType="none"
+                    />
+                    {activeDrivers.map((abbr) => (
+                      <Line
+                        key={abbr}
+                        type="monotone"
+                        dataKey={abbr}
+                        stroke={getDriverColor(abbr)}
+                        strokeWidth={1.5}
+                        dot={false}
+                        connectNulls={false}
+                        name={abbr}
+                      />
+                    ))}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+
+            {/* Lap list */}
+            <div className="px-3 pb-2">
+              {/* Header row */}
+              <div className="flex items-center gap-1 py-1 border-b border-f1-border">
+                <span className="w-8 text-[9px] font-bold text-f1-muted">LAP</span>
+                {activeDrivers.map((abbr) => (
+                  <div key={abbr} className="flex-1 flex items-center gap-1">
+                    <span
+                      className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: getDriverColor(abbr) }}
+                    />
+                    <span className="text-[9px] font-bold text-f1-muted">{abbr}</span>
+                  </div>
+                ))}
+                {activeDrivers.length === 2 && (
+                  <span className="w-14 text-[9px] font-bold text-f1-muted text-right flex-shrink-0">DELTA</span>
+                )}
+              </div>
+
+              {/* Lap rows */}
+              {(() => {
+                const maxLap = Math.max(
+                  ...activeDrivers.map((d) => {
+                    const dl = driverLaps.get(d) || [];
+                    const filtered = dl.filter((l) => l.lap_number <= currentLap);
+                    return filtered.length > 0 ? filtered[filtered.length - 1].lap_number : 0;
+                  }),
+                );
+                const rows = [];
+                for (let lap = 1; lap <= maxLap; lap++) {
+                  rows.push(
+                    <div
+                      key={lap}
+                      className={`flex items-center gap-1 py-0.5 ${lap === currentLap ? "bg-white/5" : ""}`}
+                    >
+                      <span className="w-8 text-[10px] font-bold text-f1-muted tabular-nums">{lap}</span>
+                      {activeDrivers.map((abbr) => {
+                        const dl = driverLaps.get(abbr) || [];
+                        const entry = dl.find((l) => l.lap_number === lap);
+                        const isPit = entry?.pit_in || entry?.pit_out;
+                        const compound = entry?.compound;
+                        const tyreColor = compound ? TYRE_COLORS[compound] || "#888" : undefined;
+                        const tyreLabel = compound ? TYRE_SHORT[compound] || "?" : null;
+
+                        return (
+                          <div key={abbr} className="flex-1 flex items-center gap-1">
+                            <span
+                              className={`text-[10px] tabular-nums ${
+                                isPit ? "text-yellow-400" : "text-white"
+                              }`}
+                            >
+                              {entry?.lap_time || "—"}
+                            </span>
+                            {isPit && (
+                              <span className="text-[8px] font-bold text-yellow-400">PIT</span>
+                            )}
+                            {tyreLabel && (
+                              <span
+                                className="w-3 h-3 rounded-full flex items-center justify-center text-[6px] font-extrabold leading-none border flex-shrink-0"
+                                style={{ borderColor: tyreColor, color: tyreColor }}
+                              >
+                                {tyreLabel}
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })}
+                      {activeDrivers.length === 2 && (() => {
+                        const dl0 = driverLaps.get(activeDrivers[0]) || [];
+                        const dl1 = driverLaps.get(activeDrivers[1]) || [];
+                        const e0 = dl0.find((l) => l.lap_number === lap);
+                        const e1 = dl1.find((l) => l.lap_number === lap);
+                        const t0 = e0?.lap_time ? parseLapTime(e0.lap_time) : null;
+                        const t1 = e1?.lap_time ? parseLapTime(e1.lap_time) : null;
+                        if (t0 === null || t1 === null) return <span className="w-14 flex-shrink-0" />;
+                        // Delta from driver 1's perspective: positive = driver 1 slower, negative = driver 1 faster
+                        const delta = t0 - t1;
+                        const absDelta = Math.abs(delta);
+                        const sign = delta > 0.001 ? "+" : delta < -0.001 ? "-" : "";
+                        const color = delta < -0.001 ? "text-green-400" : delta > 0.001 ? "text-red-400" : "text-f1-muted";
+                        return (
+                          <span className={`w-14 flex-shrink-0 text-[10px] font-bold tabular-nums text-right ${color}`}>
+                            {sign}{absDelta.toFixed(3)}
+                          </span>
+                        );
+                      })()}
+                    </div>,
+                  );
+                }
+                return rows;
+              })()}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -5,6 +5,15 @@ import { ReplayDriver } from "@/hooks/useReplaySocket";
 import { ReplaySettings } from "@/hooks/useSettings";
 import { TYRE_COLORS, TYRE_SHORT, TEAM_ABBR } from "@/lib/constants";
 
+export interface LapEntry {
+  driver: string;
+  lap_number: number;
+  lap_time: string | null;
+  compound: string | null;
+  pit_in: boolean;
+  pit_out: boolean;
+}
+
 interface Props {
   drivers: ReplayDriver[];
   highlightedDrivers: string[];
@@ -15,6 +24,9 @@ interface Props {
   isQualifying?: boolean;
   compact?: boolean;
   onScaleChange?: (scale: number) => void;
+  lapData?: Map<string, Map<number, string>>;
+  currentLap?: number;
+  mobileTeamAbbrHidden?: boolean;
 }
 
 function formatGap(gap: string | null): string {
@@ -73,7 +85,7 @@ function computeIntervals(sorted: ReplayDriver[]): Map<string, string> {
   return intervals;
 }
 
-export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick, settings, currentTime, isRace, isQualifying, compact, onScaleChange }: Props) {
+export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick, settings, currentTime, isRace, isQualifying, compact, onScaleChange, lapData, currentLap, mobileTeamAbbrHidden }: Props) {
   const [showInterval, setShowInterval] = useState(true);
   const [scale, setScale] = useState(1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -105,7 +117,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
     updateScale();
     window.addEventListener("resize", updateScale);
     return () => window.removeEventListener("resize", updateScale);
-  }, [drivers.length, settings.showGapToLeader, settings.showBestLapTime, isRace, compact, onScaleChange]);
+  }, [drivers.length, settings.showGapToLeader, settings.showBestLapTime, settings.showLastLapTime, isRace, compact, onScaleChange]);
 
   const sorted = [...drivers].sort(
     (a, b) => (a.position ?? 999) - (b.position ?? 999),
@@ -167,8 +179,8 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
               />
 
               {/* Team abbreviation - 28px */}
-              {settings.showTeamAbbr && (
-                <span className="w-7 text-[10px] font-bold text-f1-muted flex-shrink-0">
+              {settings.showTeamAbbr && !mobileTeamAbbrHidden && (
+                <span className="w-7 text-[10px] font-bold text-f1-muted flex-shrink-0" title="Team">
                   {TEAM_ABBR[drv.team] || drv.team?.slice(0, 3).toUpperCase()}
                 </span>
               )}
@@ -191,7 +203,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Grid delta - 24px (race only) */}
               {isRace && settings.showGridChange && (
-              <span className="w-6 flex-shrink-0 text-center">
+              <span className="w-6 flex-shrink-0 text-center" title="Grid position change">
                 {!drv.retired && currentTime >= 10 && (
                   drv.pit_start ? (
                     <span className="text-[10px] font-bold text-white">Pit</span>
@@ -232,7 +244,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Best lap time (practice/qualifying only) */}
               {!isRace && settings.showBestLapTime && (
-                <span className={`w-[60px] flex-shrink-0 text-xs font-bold text-right ${drv.position === 1 ? "text-purple-400" : "text-white"}`}>
+                <span className={`w-[60px] flex-shrink-0 text-xs font-bold text-right ${drv.position === 1 ? "text-purple-400" : "text-white"}`} title="Best lap time">
                   {drv.retired ? "Out" : (drv.best_lap_time || (drv.position === 1 ? formatGap(drv.gap) : null) || "")}
                 </span>
               )}
@@ -250,14 +262,14 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
                   </span>
                 ) : isRace ? (
                   drv.in_pit && !drv.retired ? (
-                    <span className="w-14 flex-shrink-0 text-left text-yellow-400">
+                    <span className="w-14 flex-shrink-0 text-left text-yellow-400" title="In pit lane">
                       <span className="text-xs font-bold">PIT</span>
                       {drv.pit_time != null && (
                         <span className="text-[9px] font-bold ml-0.5 tabular-nums">{drv.pit_time.toFixed(1)}s</span>
                       )}
                     </span>
                   ) : (
-                    <span className={`w-14 flex-shrink-0 text-xs font-bold text-left tabular-nums ${
+                    <span title={showInterval ? "Interval to car ahead" : "Gap to leader"} className={`w-14 flex-shrink-0 text-xs font-bold text-left tabular-nums ${
                       showInterval && settings.highlightClose && displayGap && (() => {
                           const val = parseFloat(displayGap.replace("+", ""));
                           return !isNaN(val) && val > 0 && val < 1;
@@ -269,11 +281,29 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
                     </span>
                   )
                 ) : (
-                  <span className={`w-14 flex-shrink-0 text-xs font-bold text-left tabular-nums text-f1-muted`}>
+                  <span className={`w-14 flex-shrink-0 text-xs font-bold text-left tabular-nums text-f1-muted sm:ml-0 ml-3`} title="Gap to leader">
                     {displayGap}
                   </span>
                 )
               )}
+
+              {/* Last lap time (race only) */}
+              {isRace && settings.showLastLapTime && (() => {
+                const driverLaps = lapData?.get(drv.abbr);
+                if (!driverLaps || !currentLap || currentLap < 2) return (
+                  <span className="w-[52px] sm:w-[60px] flex-shrink-0" />
+                );
+                let lastLapTime: string | null = null;
+                for (let l = currentLap; l >= 1; l--) {
+                  const t = driverLaps.get(l);
+                  if (t) { lastLapTime = t; break; }
+                }
+                return (
+                  <span className="w-[52px] sm:w-[60px] flex-shrink-0 text-[11px] sm:text-xs text-right tabular-nums text-f1-muted" title="Last lap time">
+                    {drv.retired ? "" : (lastLapTime || "")}
+                  </span>
+                );
+              })()}
 
               {/* Live sector indicators - fixed width (qualifying only) */}
               {isQualifying && settings.showSectors && (
@@ -297,7 +327,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Pit stops / chequered flag - 20px (race only) */}
               {isRace && settings.showPitStops && (
-                <span className="w-5 flex-shrink-0 flex items-center justify-center ml-1">
+                <span className="w-5 flex-shrink-0 flex items-center justify-center ml-1" title={drv.finished ? "Finished" : "Pit stops"}>
                   {drv.finished ? (
                     <img src="/chequered-flag.png" alt="Finished" className="w-5 h-5 object-contain" />
                   ) : drv.pit_stops > 0 ? (
@@ -310,7 +340,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Pit prediction - 36px (race only) */}
               {isRace && settings.showPitPrediction && (
-                <span className="w-9 flex-shrink-0 flex items-center justify-end gap-0.5 ml-1">
+                <span className="w-9 flex-shrink-0 flex items-center justify-end gap-0.5 ml-1" title="Predicted position after pit stop">
                   {drv.pit_prediction != null && (
                     <>
                       <span className={`flex items-center gap-0.5 text-[10px] font-bold ${
@@ -333,7 +363,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Pit gaps (ahead / behind) stacked - race only, shown with pit prediction */}
               {isRace && settings.showPitPrediction && settings.showPitFreeAir && (
-                <span className="w-9 flex-shrink-0 flex flex-col items-end leading-tight">
+                <span className="w-9 flex-shrink-0 flex flex-col items-end leading-tight" title="Pit gaps: ↑ gap ahead, ↓ gap behind">
                   {drv.pit_prediction != null && (
                     <>
                       <span className="text-[8px] font-bold text-f1-muted">
@@ -359,7 +389,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Tyre history - 36px (race only) */}
               {isRace && settings.showTyreHistory && (
-                <span className="w-9 flex-shrink-0 flex items-center justify-end gap-0.5">
+                <span className="w-9 flex-shrink-0 flex items-center justify-end gap-0.5" title="Tyre history">
                   {(drv.tyre_history || []).slice(-2).map((comp, i) => {
                     const hColor = TYRE_COLORS[comp] || "#888";
                     const hLabel = TYRE_SHORT[comp] || "?";
@@ -382,7 +412,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Current tyre compound - 20px */}
               {settings.showTyreType && (
-                <span className="w-5 flex-shrink-0 flex items-center justify-center ml-1">
+                <span className="w-5 flex-shrink-0 flex items-center justify-center ml-1" title="Current tyre">
                   <span
                     className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-extrabold leading-none border-2"
                     style={{
@@ -398,7 +428,7 @@ export default function Leaderboard({ drivers, highlightedDrivers, onDriverClick
 
               {/* Tyre age - 20px */}
               {settings.showTyreAge && (
-                <span className="w-5 flex-shrink-0 text-xs font-extrabold text-white text-right">
+                <span className="w-5 flex-shrink-0 text-xs font-extrabold text-white text-right" title="Tyre age (laps)">
                   {drv.tyre_life ?? ""}
                 </span>
               )}

--- a/frontend/src/components/SessionBanner.tsx
+++ b/frontend/src/components/SessionBanner.tsx
@@ -14,6 +14,7 @@ interface Props {
   onSettingChange?: (key: keyof ReplaySettings, value: boolean) => void;
   weather?: WeatherData;
   extraActions?: React.ReactNode;
+  mobileTeamAbbrHidden?: boolean;
 }
 
 const SESSION_LABELS: Record<string, string> = {
@@ -30,6 +31,7 @@ const LEADERBOARD_SETTINGS: { key: keyof ReplaySettings; label: string; raceOnly
   { key: "showTeamAbbr", label: "Team" },
   { key: "showGridChange", label: "Grid position change", raceOnly: true },
   { key: "showBestLapTime", label: "Best time", nonRaceOnly: true },
+  { key: "showLastLapTime", label: "Last lap time", raceOnly: true },
   { key: "showGapToLeader", label: "Gap" },
   { key: "highlightClose", label: "Highlight under 1s", raceOnly: true },
   { key: "showPitStops", label: "Pit stops", raceOnly: true },
@@ -70,6 +72,7 @@ export default function SessionBanner({
   onSettingChange,
   weather,
   extraActions,
+  mobileTeamAbbrHidden,
 }: Props) {
   const settings = settingsProp || DEFAULT_SETTINGS;
   const isRace = sessionType === "R" || sessionType === "S";
@@ -173,10 +176,12 @@ export default function SessionBanner({
             {SESSION_LABELS[sessionType] || sessionType}
           </div>
 
-          {/* Features/info link - hidden on mobile */}
+          {/* Features/info link */}
           <a
             href="/features"
-            className="hidden sm:flex w-9 h-9 items-center justify-center rounded hover:bg-white/10 transition-colors text-f1-muted hover:text-white"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex w-8 h-8 sm:w-9 sm:h-9 items-center justify-center rounded hover:bg-white/10 transition-colors text-f1-muted hover:text-white"
             title="How it works"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -257,6 +262,9 @@ export default function SessionBanner({
                           <span className={`${parent ? "text-xs text-f1-muted" : "text-sm text-white"} flex items-center gap-2`}>
                             {label}
                             {badge && <span className="px-1.5 py-0.5 text-[9px] font-bold uppercase rounded bg-f1-red/20 text-f1-red leading-none">{badge}</span>}
+                            {key === "showTeamAbbr" && mobileTeamAbbrHidden && (
+                              <span className="px-1.5 py-0.5 text-[9px] font-bold uppercase rounded bg-yellow-500/20 text-yellow-500 leading-none">Auto-hidden on mobile</span>
+                            )}
                           </span>
                           <div className={`relative ${parent ? "w-7 h-4" : "w-9 h-5"} rounded-full transition-colors ${settings[key] ? "bg-f1-red" : "bg-f1-border"}`}>
                             <div className={`absolute top-0.5 ${parent ? "w-3 h-3" : "w-4 h-4"} bg-white rounded-full transition-transform ${settings[key] ? (parent ? "translate-x-[14px]" : "translate-x-[18px]") : "translate-x-0.5"}`} />

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -23,6 +23,7 @@ export interface ReplaySettings {
   showPitPrediction: boolean;
   showPitConfidence: boolean;
   showPitFreeAir: boolean;
+  showLastLapTime: boolean;
   showSectors: boolean;
   highlightClose: boolean;
   useImperial: boolean;
@@ -53,6 +54,7 @@ export const DEFAULTS: ReplaySettings = {
   showPitPrediction: true,
   showPitConfidence: true,
   showPitFreeAir: true,
+  showLastLapTime: true,
   showSectors: true,
   highlightClose: true,
   useImperial: false,


### PR DESCRIPTION
New features:
- Lap Analysis panel (Beta) with line chart, lap-by-lap history, and two-driver comparison with delta column. Safety car and pit laps shown as shaded bands. Lap range filter (All/Last 5/10/20). Custom tooltips with band labels and times. Desktop: floating Laps button on track map opens panel left of leaderboard. Mobile: collapsible section below leaderboard.
- Last lap time column on race leaderboard, toggleable in settings. Fetches precomputed laps.json, no backend changes needed.
- Leaderboard column tooltips on hover for all columns.
- Mobile qualifying sector overlay toggle and driver selection on track map.

Improvements:
- README updated with recent features, removed Beta from pit prediction.
- Features page: added last lap time and lap analysis entries, mobile- responsive layout with description wrapping below icons.
- Info button now visible on mobile header, opens in new tab.
- Features page back button closes tab when opened from replay.
- Mobile leaderboard spacing improved for qualifying gap column.
- Auto-hide team abbreviation on mobile when columns overflow screen, with yellow badge in settings explaining why.
- Telemetry forced to bottom layout when lap analysis panel is open.
- Race control moved above track map on mobile.
- Custom driver selector dropdowns in lap analysis with team colours.
- Same-team driver comparison uses distinct cyan colour for second driver.